### PR TITLE
Provide ImageMagick resource limit configuration

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PrefsPropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PrefsPropsUtil.java
@@ -28,7 +28,9 @@ import com.liferay.util.ContentUtil;
 
 import java.io.Serializable;
 
+import java.util.Enumeration;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.portlet.PortletPreferences;
 
@@ -266,6 +268,39 @@ public class PrefsPropsUtil {
 			return new PortalPreferencesWrapper(
 				(PortalPreferencesImpl)portalPreferencesImpl.clone());
 		}
+	}
+
+	public static Properties getProperties(
+		PortletPreferences preferences, long companyId, String prefix,
+		boolean removePrefix) {
+
+		Properties subProperties = new Properties();
+
+		Enumeration<String> enu = preferences.getNames();
+
+		while (enu.hasMoreElements()) {
+			String key = enu.nextElement();
+
+			if (key.startsWith(prefix)) {
+				String value = preferences.getValue(key, StringPool.BLANK);
+
+				if (removePrefix) {
+					key = key.substring(prefix.length());
+				}
+
+				subProperties.setProperty(key, value);
+			}
+		}
+
+		return subProperties;
+	}
+
+	public static Properties getProperties(String prefix, boolean removePrefix)
+		throws SystemException {
+
+		PortletPreferences preferences = getPreferences();
+
+		return getProperties(preferences, 0, prefix, removePrefix);
 	}
 
 	public static short getShort(long companyId, String name)

--- a/portal-impl/src/com/liferay/portlet/admin/action/EditServerAction.java
+++ b/portal-impl/src/com/liferay/portlet/admin/action/EditServerAction.java
@@ -471,6 +471,20 @@ public class EditServerAction extends PortletAction {
 		boolean xugglerEnabled = ParamUtil.getBoolean(
 			actionRequest, "xugglerEnabled");
 
+		Enumeration<String> enu = actionRequest.getParameterNames();
+
+		while (enu.hasMoreElements()) {
+			String name = enu.nextElement();
+
+			if (name.startsWith("imageMagickLimit")) {
+				String key = name.substring(16, name.length()).toLowerCase();
+				String value = ParamUtil.getString(actionRequest, name);
+
+				preferences.setValue(
+					PropsKeys.IMAGEMAGICK_RESOURCE_LIMIT + key, value);
+			}
+		}
+
 		preferences.setValue(
 			PropsKeys.IMAGEMAGICK_ENABLED, String.valueOf(imageMagickEnabled));
 		preferences.setValue(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/LiferayConvertCmd.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/LiferayConvertCmd.java
@@ -14,7 +14,15 @@
 
 package com.liferay.portlet.documentlibrary.util;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
 import java.util.LinkedList;
+import java.util.Properties;
+
+import jodd.util.StringPool;
 
 import org.im4java.core.ConvertCmd;
 
@@ -24,7 +32,8 @@ import org.im4java.core.ConvertCmd;
 public class LiferayConvertCmd extends ConvertCmd {
 
 	public static void run(
-			String globalSearchPath, LinkedList<String> commandArguments)
+			String globalSearchPath, Properties resourceLimits,
+			LinkedList<String> commandArguments)
 		throws Exception {
 
 		setGlobalSearchPath(globalSearchPath);
@@ -32,10 +41,34 @@ public class LiferayConvertCmd extends ConvertCmd {
 		LinkedList<String> arguments = new LinkedList<String>();
 
 		arguments.addAll(_instance.getCommand());
+
+		for (Object key : resourceLimits.keySet()) {
+			String value = (String)resourceLimits.get(key);
+
+			if (Validator.isNotNull(value)) {
+				arguments.add("-limit");
+				arguments.add((String)key);
+				arguments.add(value);
+			}
+		}
+
 		arguments.addAll(commandArguments);
+
+		if (_log.isInfoEnabled()) {
+			StringBundler sb = new StringBundler(arguments.size() * 2);
+
+			for (String argument : arguments) {
+				sb.append(argument);
+				sb.append(StringPool.SPACE);
+			}
+
+			_log.info("Excecuting command '" + sb.toString() + "'");
+		}
 
 		_instance.run(arguments);
 	}
+
+	private static Log _log = LogFactoryUtil.getLog(LiferayConvertCmd.class);
 
 	private static LiferayConvertCmd _instance = new LiferayConvertCmd();
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
@@ -53,6 +53,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 
@@ -65,9 +66,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
 import org.apache.pdfbox.pdmodel.PDPage;
 
-import org.im4java.core.ConvertCmd;
 import org.im4java.core.IMOperation;
-import org.im4java.process.ProcessStarter;
 
 /**
  * @author Alexander Chow
@@ -136,6 +135,18 @@ public class PDFProcessorImpl
 
 		return Initializer._initializedInstance.doGetPreviewFileSize(
 			fileVersion, index);
+	}
+
+	public Properties getResourceLimits() throws Exception {
+		Properties resourceLimits = PrefsPropsUtil.getProperties(
+			PropsKeys.IMAGEMAGICK_RESOURCE_LIMIT, true);
+
+		if (resourceLimits.isEmpty()) {
+			resourceLimits = PropsUtil.getProperties(
+				PropsKeys.IMAGEMAGICK_RESOURCE_LIMIT, true);
+		}
+
+		return resourceLimits;
 	}
 
 	public InputStream getThumbnailAsStream(
@@ -231,12 +242,7 @@ public class PDFProcessorImpl
 		if (isImageMagickEnabled()) {
 			_globalSearchPath = getGlobalSearchPath();
 
-			ProcessStarter.setGlobalSearchPath(_globalSearchPath);
-
-			_convertCmd = new ConvertCmd();
-		}
-		else {
-			_convertCmd = null;
+			_resourceLimits = getResourceLimits();
 		}
 	}
 
@@ -422,20 +428,18 @@ public class PDFProcessorImpl
 			imOperation.addImage(getPreviewTempFilePath(tempFileId, -1));
 		}
 
-		if (_log.isInfoEnabled()) {
-			_log.info("Excecuting command 'convert " + imOperation + "'");
-		}
-
 		if (PropsValues.DL_FILE_ENTRY_PREVIEW_FORK_PROCESS_ENABLED) {
 			ProcessCallable<String> processCallable =
 				new ImageMagickProcessCallable(
-					_globalSearchPath, imOperation.getCmdArgs());
+					_globalSearchPath, _resourceLimits,
+					imOperation.getCmdArgs());
 
 			ProcessExecutor.execute(
 				processCallable, ClassPathUtil.getPortalClassPath());
 		}
 		else {
-			_convertCmd.run(imOperation);
+			LiferayConvertCmd.run(
+				_globalSearchPath, _resourceLimits, imOperation.getCmdArgs());
 		}
 
 		// Store images
@@ -729,24 +733,27 @@ public class PDFProcessorImpl
 		InstancePool.put(PDFProcessorImpl.class.getName(), _instance);
 	}
 
-	private ConvertCmd _convertCmd;
 	private List<Long> _fileVersionIds = new Vector<Long>();
 	private String _globalSearchPath;
+	private Properties _resourceLimits;
 	private boolean _warned;
 
 	private static class ImageMagickProcessCallable
 		implements ProcessCallable<String> {
 
 		public ImageMagickProcessCallable(
-			String globalSearchPath, LinkedList<String> commandArguments) {
+			String globalSearchPath, Properties resourceLimits,
+			LinkedList<String> commandArguments) {
 
 			_globalSearchPath = globalSearchPath;
 			_commandArguments = commandArguments;
+			_resourceLimits = resourceLimits;
 		}
 
 		public String call() throws ProcessException {
 			try {
-				LiferayConvertCmd.run(_globalSearchPath, _commandArguments);
+				LiferayConvertCmd.run(
+					_globalSearchPath, _resourceLimits, _commandArguments);
 			}
 			catch (Exception e) {
 				throw new ProcessException(e);
@@ -757,6 +764,7 @@ public class PDFProcessorImpl
 
 		private LinkedList<String> _commandArguments;
 		private String _globalSearchPath;
+		private Properties _resourceLimits;
 
 	}
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -1,3 +1,7 @@
+resource-limits=Resource Limits
+disk=Disk
+map=Map
+
 ##
 ## Language settings
 ##

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5456,6 +5456,23 @@
     imagemagick.global.search.path[unix]=/usr/local/bin:/usr/local/share/ghostscript/fonts:/usr/local/share/fonts/urw-fonts
     imagemagick.global.search.path[windows]=C:\\Program Files\\ImageMagick
 
+    # 
+    # Set these limits to configure the cache and resource usage of ImageMagick.
+    # To determine the current setting of these limits, run the command:
+    #
+    # identify -list resource
+    #
+    # See http://www.imagemagick.org/script/architecture.php for more 
+    # information.
+    #
+    imagemagick.resource.limit.area=2GiB
+    #imagemagick.resource.limit.disk=16GiB
+    #imagemagick.resource.limit.file=256
+    imagemagick.resource.limit.map=1GiB
+    imagemagick.resource.limit.memory=2GiB
+    #imagemagick.resource.limit.thread=2
+    #imagemagick.resource.limit.time=3600
+
 ##
 ## Invoker
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -791,6 +791,8 @@ public interface PropsKeys {
 
 	public static final String IMAGEMAGICK_GLOBAL_SEARCH_PATH = "imagemagick.global.search.path";
 
+	public static final String IMAGEMAGICK_RESOURCE_LIMIT = "imagemagick.resource.limit.";
+
 	public static final String INDEX_DATE_FORMAT_PATTERN = "index.date.format.pattern";
 
 	public static final String INDEX_DUMP_COMPRESSION_ENABLED = "index.dump.compression.enabled";

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/PDFProcessor.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/PDFProcessor.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 
 import java.io.InputStream;
 
+import java.util.Properties;
+
 /**
  * @author Sergio González
  */
@@ -40,6 +42,8 @@ public interface PDFProcessor {
 
 	public long getPreviewFileSize(FileVersion fileVersion, int index)
 		throws Exception;
+
+	public Properties getResourceLimits() throws Exception;
 
 	public InputStream getThumbnailAsStream(
 			FileVersion fileVersion, int thumbnailIndex)

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/PDFProcessorUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/PDFProcessorUtil.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 
 import java.io.InputStream;
 
+import java.util.Properties;
+
 /**
  * @author Sergio González
  */
@@ -52,6 +54,10 @@ public class PDFProcessorUtil {
 		throws Exception {
 
 		return getPDFProcessor().getPreviewFileSize(fileVersion, index);
+	}
+
+	public static Properties getResourceLimits() throws Exception {
+		return getPDFProcessor().getResourceLimits();
 	}
 
 	public static InputStream getThumbnailAsStream(

--- a/portal-web/docroot/html/portlet/admin/server.jspf
+++ b/portal-web/docroot/html/portlet/admin/server.jspf
@@ -550,6 +550,26 @@ numberFormat.setMinimumIntegerDigits(2);
 							<aui:input inlineLabel="right" label="enabled" name="imageMagickEnabled" type="checkbox" value="<%= PrefsPropsUtil.getBoolean(PropsKeys.IMAGEMAGICK_ENABLED) %>" />
 
 							<aui:input cssClass="lfr-input-text-container" label="path" name="imageMagickPath" type="text" value="<%= PDFProcessorUtil.getGlobalSearchPath() %>" />
+
+							<aui:fieldset label="resource-limits">
+
+								<%
+								Properties resourceLimits = PDFProcessorUtil.getResourceLimits();
+
+								String[] labels = new String[] { "area", "disk", "file", "map", "memory", "thread", "time" };
+
+								for (String label : labels) {
+									String value = (String)resourceLimits.get(label);
+									String name = "imageMagickLimit" + StringUtil.upperCaseFirstLetter(label);
+								%>
+
+									<aui:input cssClass="lfr-input-text-container" label="<%= label %>" name="<%= name %>" type="text" value="<%= value %>" />
+
+								<%
+								}
+								%>
+
+							</aui:fieldset>
 						</liferay-ui:panel>
 
 						<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="adminOpenOfficeConversionPanel" persistState="<%= true %>" title="enabling-openoffice-integration-provides-document-conversion-functionality">


### PR DESCRIPTION
Hey Ray,

I updated the code to have configurability from the portal of resource/cache limits.  By lowering the memory values, I was able to consume less memory but take more time, of course.  Also, as I mentioned before, the throttling of the CPU is only configurable via environment variables or the policy.xml.  So, that is not included here.

I haven't created a ticket because of GA.  Also, there is a workaround available.  In any case, I coded it up so that you can take a look at it and see if it helps fix your issues.  It seems to control things fine for me.

Alex
