### PR TITLE
LPS-25546 Change workflow status when turn on staging

### DIFF
--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -60,6 +60,7 @@ import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutBranch;
 import com.liferay.portal.model.LayoutRevision;
 import com.liferay.portal.model.LayoutSet;
+import com.liferay.portal.model.LayoutSetBranch;
 import com.liferay.portal.model.LayoutSetBranchConstants;
 import com.liferay.portal.model.Lock;
 import com.liferay.portal.model.Portlet;
@@ -1409,11 +1410,22 @@ public class StagingImpl implements Staging {
 				liveGroup.getDescriptiveName());
 
 			try {
-				LayoutSetBranchLocalServiceUtil.addLayoutSetBranch(
-					userId, targetGroupId, false,
-					LayoutSetBranchConstants.MASTER_BRANCH_NAME, description,
-					true, LayoutSetBranchConstants.ALL_BRANCHES,
-					serviceContext);
+				LayoutSetBranch layoutSetBranch =
+					LayoutSetBranchLocalServiceUtil.addLayoutSetBranch(
+						userId, targetGroupId, false,
+						LayoutSetBranchConstants.MASTER_BRANCH_NAME,
+						description, true,
+						LayoutSetBranchConstants.ALL_BRANCHES, serviceContext);
+
+				List<LayoutRevision> revisions =
+					LayoutRevisionLocalServiceUtil.getLayoutRevisions(
+						layoutSetBranch.getLayoutSetBranchId(), false);
+
+				for (LayoutRevision revision : revisions) {
+					LayoutRevisionLocalServiceUtil.updateStatus(
+						userId, revision.getLayoutRevisionId(),
+						WorkflowConstants.STATUS_APPROVED, serviceContext);
+				}
 			}
 			catch (LayoutSetBranchNameException lsbne) {
 			}
@@ -1428,11 +1440,22 @@ public class StagingImpl implements Staging {
 				liveGroup.getDescriptiveName());
 
 			try {
-				LayoutSetBranchLocalServiceUtil.addLayoutSetBranch(
-					userId, targetGroupId, true,
-					LayoutSetBranchConstants.MASTER_BRANCH_NAME, description,
-					true, LayoutSetBranchConstants.ALL_BRANCHES,
-					serviceContext);
+				LayoutSetBranch layoutSetBranch =
+					LayoutSetBranchLocalServiceUtil.addLayoutSetBranch(
+						userId, targetGroupId, true,
+						LayoutSetBranchConstants.MASTER_BRANCH_NAME,
+						description, true,
+						LayoutSetBranchConstants.ALL_BRANCHES, serviceContext);
+
+				List<LayoutRevision> revisions =
+					LayoutRevisionLocalServiceUtil.getLayoutRevisions(
+						layoutSetBranch.getLayoutSetBranchId(), false);
+
+				for (LayoutRevision revision : revisions) {
+					LayoutRevisionLocalServiceUtil.updateStatus(
+						userId, revision.getLayoutRevisionId(),
+						WorkflowConstants.STATUS_APPROVED, serviceContext);
+				}
 			}
 			catch (LayoutSetBranchNameException lsbne) {
 			}


### PR DESCRIPTION
Hello Ray,

this is the fix we have talked about some days ago. I hesitated between two ways to resolve the problem:

1, add a servicecontext attribute (e.g.: enableStagingInProgress) and update the status when the service creates the new layoutrevision objects and variable value is true.(like imported in JALSI.updateArticle())  It could be good because we do all the operations only once, but it is bad because we have to modify the very generic add method and it is hard to find the connection between staging and layoutRevisionLocalService for the other programmers. 

2, use stagingImpl because logically this component requires the status update. In this way we have to query up one more time all the newly created revision and mass update them. 

I chose the 2nd because for me it is a more clear and more easily maintainable solution. 

Please let me know your opinion!

Thanks,
Daniel
