### PR TITLE
[TECHNICAL-SUPPORT] LPS-34697 Web Content (JournalArticle) default locale is not fully considered in the index and in the search query when it is different from the default locale of the portal

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalArticleIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalArticleIndexer.java
@@ -427,6 +427,11 @@ public class JournalArticleIndexer extends BaseIndexer {
 
 		Locale snippetLocale = getSnippetLocale(document, locale);
 
+		if (snippetLocale == null) {
+			snippetLocale = LocaleUtil.fromLanguageId(
+				document.get("defaultLanguageId"));
+		}
+
 		String prefix = Field.SNIPPET + StringPool.UNDERLINE;
 
 		String title = document.get(
@@ -436,11 +441,8 @@ public class JournalArticleIndexer extends BaseIndexer {
 			snippetLocale, prefix + Field.DESCRIPTION, prefix + Field.CONTENT);
 
 		if (Validator.isBlank(content)) {
-			content = document.get(locale, Field.DESCRIPTION, Field.CONTENT);
-
-			if (Validator.isBlank(content)) {
-				content = document.get(Field.DESCRIPTION, Field.CONTENT);
-			}
+			content = document.get(
+				snippetLocale, Field.DESCRIPTION, Field.CONTENT);
 		}
 
 		if (content.length() > 200) {

--- a/portal-web/docroot/html/portlet/journal_content_search/article_language.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/article_language.jsp
@@ -23,10 +23,6 @@ Object[] objArray = (Object[])row.getObject();
 
 Locale snippetLocale = ((Summary)objArray[2]).getLocale();
 
-if (snippetLocale == null) {
-	snippetLocale = LocaleUtil.getDefault();
-}
-
 String languageId = LocaleUtil.toLanguageId(snippetLocale);
 %>
 


### PR DESCRIPTION
Hi Ray,

I've finished testing the changes that Brian asked.
As getSnipetLocale() belongs to the BaseIndexer, and my null-check relies on a non-general field, I placed it at the top of JournalArticleIndexer.doGetSummary().

I also have modified the "isBlank" checks for content, since we should use the snipetLocale and it cannot be null with new changes.

Please, review my new changes.

Thanks,
Tibor
