### PR TITLE
Lps 31348 mail index

### DIFF
--- a/portal-impl/src/META-INF/search-spring.xml
+++ b/portal-impl/src/META-INF/search-spring.xml
@@ -139,7 +139,7 @@
 		<constructor-arg>
 			<util:map map-class="java.util.LinkedHashMap">
 				<entry key="assetCategoryTitles(_.+)?" value-ref="com.liferay.portal.search.lucene.LikeKeywordAnalyzer" />
-				<entry key="assetTagNames" value-ref="com.liferay.portal.search.lucene.LikeKeywordAnalyzer" />				
+				<entry key="assetTagNames" value-ref="com.liferay.portal.search.lucene.LikeKeywordAnalyzer" />
 				<entry key="ddm/.*" value-ref="org.apache.lucene.analysis.KeywordAnalyzer" />
 				<entry key="emailAddress" value-ref="com.liferay.portal.search.lucene.LikeKeywordAnalyzer" />
 				<entry key="entryClassName" value-ref="org.apache.lucene.analysis.KeywordAnalyzer" />


### PR DESCRIPTION
Hi Ray!

This is one of the 6.1.30 issues that should be solved, so here I send you a PR.

After some findings I saw that Lucene 3.5 changed some Analyzers/Tokenizers and was affecting email searching: http://lucene.472066.n3.nabble.com/StandardAnalyzer-and-Email-Addresses-td3751058.html

For testing, instead of using Advanced search, like LPS says, just use the right panel (Keywords), because left Advanced search seems broken (http://issues.liferay.com/browse/LPS-35699). In ee-6.1.x can be tested fine anyway.

There is a workaround for using Advanced search but perhaps is too complicated for only testing a single line.

Thanks!
