### PR TITLE
LPS-35657 changed _getViewFullContentURL to load the results in the same page

### DIFF
--- a/portal-web/docroot/html/portlet/search/init.jsp
+++ b/portal-web/docroot/html/portlet/search/init.jsp
@@ -153,14 +153,16 @@ private PortletURL _getViewFullContentURL(HttpServletRequest request, ThemeDispl
 		scopeGroupId = themeDisplay.getScopeGroupId();
 	}
 
-	long plid = LayoutServiceUtil.getDefaultPlid(groupId, scopeGroupId, portletId);
+	long plid = LayoutConstants.DEFAULT_PLID;
+
+	Layout layout = (Layout)request.getAttribute(WebKeys.LAYOUT);
+
+	if (layout != null) {
+		plid = layout.getPlid();
+	}
 
 	if (plid == 0) {
-		Layout layout = (Layout)request.getAttribute(WebKeys.LAYOUT);
-
-		if (layout != null) {
-			plid = layout.getPlid();
-		}
+		plid = LayoutServiceUtil.getDefaultPlid(groupId, scopeGroupId, portletId);
 	}
 
 	PortletURL portletURL = PortletURLFactoryUtil.create(request, portletId, plid, PortletRequest.RENDER_PHASE);


### PR DESCRIPTION
The URL generated in _getViewFullContentURL now loads the content in the same page that the search is done.

If viewInContext option is selected, then the URL is generated by the assetRenderer, and the previous URL is used as fallback:

assetRenderer.getURLViewInContext(liferayPortletRequest, liferayPortletResponse, viewFullContentURLString);
