### PR TITLE
LPS-35364 Send the proper port to checkConnect method

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/security/pacl/permission/PortalSocketPermission.java
+++ b/portal-service/src/com/liferay/portal/kernel/security/pacl/permission/PortalSocketPermission.java
@@ -27,18 +27,22 @@ import java.net.URL;
 public class PortalSocketPermission {
 
 	public static void checkConnect(Http.Options options) {
-		String location = options.getLocation();
-
-		String domain = HttpUtil.getDomain(location);
-		int port = -1;
-		String protocol = HttpUtil.getProtocol(location);
-
-		checkConnect(domain, port, protocol);
+		checkConnect(options.getLocation());
 	}
 
 	public static void checkConnect(String location) {
-		String domain = HttpUtil.getDomain(location);
+		String domainAndPort = HttpUtil.getDomain(location);
+
+		String[] domainAndPortArray = domainAndPort.split(StringPool.COLON);
+
+		String domain = domainAndPortArray[0];
+
 		int port = -1;
+
+		if (domainAndPortArray.length > 1) {
+			port = Integer.parseInt(domainAndPortArray[1]);
+		}
+
 		String protocol = HttpUtil.getProtocol(location);
 
 		checkConnect(domain, port, protocol);


### PR DESCRIPTION
Hey  Ray.

This is a small fix in the PortalSocketPermission.checkConnect method, that is used when PACL is enabled and,  for example, we want to send a callback for a blog entry.

The root problem is that the checkConnect method selects always the port 80/443, even if the url has a port like 8080.

However, in master there is another error with the trackbacks that is not reproduced in 6.1.x.  It is important to notice that this second error doesn't have relation with this fix and its cause.

We need to backport this as soon as possible because this error is a release blocker of GA3 release (the release has to be completed this week), so the last part of the fix that is only related with master will be included in another commit.

PD: There is another problem related with HttpImpl.getDomain(String url). This method returns the port too. I will fix this problem in master in a separate commit (this commit will be backported as I told you before, and we couldn't change the behaviour of a public api in a backport)

If you have doubt, please do not hesitate to ask me.

Thanks.
