### PR TITLE
LPS-43449 Able to add any kind of portlet using the move portlet action

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -785,10 +785,27 @@ public class LayoutTypePortletImpl
 			long userId, String portletId, String columnId, int columnPos)
 		throws PortalException, SystemException {
 
+		try {
+			PermissionChecker permissionChecker =
+				PermissionThreadLocal.getPermissionChecker();
+
+			if ((!LayoutPermissionUtil.contains(
+					permissionChecker, getLayout(), ActionKeys.UPDATE) &&
+				 !isCustomizable()) || !hasPortletId(portletId)) {
+
+				return;
+			}
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			return;
+		}
+
 		_enablePortletLayoutListener = false;
 
 		try {
-			removePortletId(userId, portletId, false);
+			removePortletId(userId, portletId, false, false);
 			addPortletId(userId, portletId, columnId, columnPos, false, true);
 		}
 		finally {


### PR DESCRIPTION
Hi @rotty3000,

To solve this issue I have followed the pattern you have used in https://issues.liferay.com/browse/LPS-23874

In other words, for the move portlet operation we don't need to check permissions for remove and add operation we just need to know two things:
1- The user has UPDATE permissions over the layout (we also checked this permission before my changes but in addPortet operation)
2- The portlet is on the layout (this check avoids the security issue explained in https://issues.liferay.com/browse/LPS-43449)

Thanks!
