### PR TITLE
LPS-45356 Struts action calls must respect control panel context

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/tree_js.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/tree_js.jsp
@@ -267,9 +267,13 @@ if (!selectableTree) {
 								data: function(node) {
 									return {
 										cmd: 'get',
+										controlPanelCategory: 'current_site.pages',
+										doAsGroupId: themeDisplay.getScopeGroupId(),
 										groupId: TreeUtil.extractGroupId(node),
 										incomplete: <%= incomplete %>,
 										p_auth: Liferay.authToken,
+										p_l_id: themeDisplay.getPlid(),
+										p_p_id: '88',
 										parentLayoutId: TreeUtil.extractLayoutId(node),
 										privateLayout: <%= privateLayout %>,
 										selPlid: '<%= selPlid %>',
@@ -661,9 +665,13 @@ if (!selectableTree) {
 					data: function(node) {
 						return {
 							cmd: 'get',
+							controlPanelCategory: 'current_site.pages',
+							doAsGroupId: themeDisplay.getScopeGroupId(),
 							groupId: TreeUtil.extractGroupId(node),
 							incomplete: <%= incomplete %>,
 							p_auth: Liferay.authToken,
+							p_l_id: themeDisplay.getPlid(),
+							p_p_id: '88',
 							parentLayoutId: TreeUtil.extractLayoutId(node),
 							privateLayout: <%= privateLayout %>,
 							selPlid: '<%= selPlid %>',


### PR DESCRIPTION
Hi Ray,

I hope you don't mind it's only a JavaScript code. 

I sent it to you because you reviewed the previous solution (#422). 

Let me know if I should send it rather to @JorgeFerrer, it's related to control panel portlets permission checking. 

@daledotshan: There are 2 problems:
1, missing p_l_id parameter in the call ... portal used the default layout for the user and there is no portlet 88 in this layout
2, missing control panel context. When we have a control panel portlet, we should include controlPanelCategory & scopeGroupId (doAsGroupId) in every call so that our permission system is able to check the site permissions/roles.

Thanks!
