### PR TITLE
LPS-46724 Image Cropper does not work in IE10 or IE11 and image cannot b...

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/PortletAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortletAction.java
@@ -465,10 +465,19 @@ public class PortletAction extends Action {
 			Object json)
 		throws IOException {
 
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			portletRequest);
+
+		String contentType = ContentTypes.APPLICATION_JSON;
+
+		if (BrowserSnifferUtil.isIe(request)) {
+			contentType = ContentTypes.TEXT_HTML;
+		}
+
 		HttpServletResponse response = PortalUtil.getHttpServletResponse(
 			actionResponse);
 
-		response.setContentType(ContentTypes.APPLICATION_JSON);
+		response.setContentType(contentType);
 
 		ServletResponseUtil.write(response, json.toString());
 
@@ -482,7 +491,16 @@ public class PortletAction extends Action {
 			Object json)
 		throws IOException {
 
-		mimeResponse.setContentType(ContentTypes.APPLICATION_JSON);
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			portletRequest);
+
+		String contentType = ContentTypes.APPLICATION_JSON;
+
+		if (BrowserSnifferUtil.isIe(request)) {
+			contentType = ContentTypes.TEXT_HTML;
+		}
+
+		mimeResponse.setContentType(contentType);
 
 		PortletResponseUtil.write(mimeResponse, json.toString());
 

--- a/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
@@ -51,6 +52,7 @@ import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 import javax.portlet.WindowState;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -383,10 +385,19 @@ public class LiferayPortlet extends GenericPortlet {
 			Object json)
 		throws IOException {
 
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			portletRequest);
+
+		String contentType = ContentTypes.APPLICATION_JSON;
+
+		if (BrowserSnifferUtil.isIe(request)) {
+			contentType = ContentTypes.TEXT_HTML;
+		}
+
 		HttpServletResponse response = PortalUtil.getHttpServletResponse(
 			actionResponse);
 
-		response.setContentType(ContentTypes.APPLICATION_JSON);
+		response.setContentType(contentType);
 
 		ServletResponseUtil.write(response, json.toString());
 
@@ -398,7 +409,16 @@ public class LiferayPortlet extends GenericPortlet {
 			Object json)
 		throws IOException {
 
-		mimeResponse.setContentType(ContentTypes.APPLICATION_JSON);
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			portletRequest);
+
+		String contentType = ContentTypes.APPLICATION_JSON;
+
+		if (BrowserSnifferUtil.isIe(request)) {
+			contentType = ContentTypes.TEXT_HTML;
+		}
+
+		mimeResponse.setContentType(contentType);
 
 		PortletResponseUtil.write(mimeResponse, json.toString());
 


### PR DESCRIPTION
Hey @rotty3000

I asked Jon Mak who to send Java changes to and he sent me in your direction. 

This is a fix for LPS-46724. The issue is that IE chokes on responses when the contentType is set to application/json, it ends up reading it as text/javascript, and prompts you to open a js file that has the json results inside, as opposed to passing the results to whatever code is handling the response.

Let me know if you have any questions. Thanks!
