### PR TITLE
LPS-47303 Comments API: transfer all Message Boards references from BaseIndexer

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -139,6 +139,14 @@ public class DLFileEntryIndexer extends BaseIndexer {
 	}
 
 	@Override
+	public void contributeToFullQuery(SearchContext searchContext) {
+		if (searchContext.isIncludeAttachments()) {
+			searchContext.addEntryClassNameForFullQuery(
+				DLFileEntry.class.getName());
+		}
+	}
+
+	@Override
 	public String[] getClassNames() {
 		return CLASS_NAMES;
 	}

--- a/portal-impl/src/com/liferay/portlet/messageboards/util/MBMessageIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/util/MBMessageIndexer.java
@@ -107,6 +107,16 @@ public class MBMessageIndexer extends BaseIndexer {
 	}
 
 	@Override
+	public void contributeToFullQuery(SearchContext searchContext) {
+		if (searchContext.isIncludeDiscussions()) {
+			searchContext.addEntryClassNameForFullQuery(
+				MBMessage.class.getName());
+
+			searchContext.setAttribute("discussion", Boolean.TRUE);
+		}
+	}
+
+	@Override
 	public String[] getClassNames() {
 		return CLASS_NAMES;
 	}

--- a/portal-service/src/com/liferay/portal/kernel/search/DummyIndexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/DummyIndexer.java
@@ -34,6 +34,10 @@ public class DummyIndexer implements Indexer {
 	}
 
 	@Override
+	public void contributeToFullQuery(SearchContext searchContext) {
+	}
+
+	@Override
 	public void delete(long companyId, String uid) {
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/search/Indexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Indexer.java
@@ -35,6 +35,8 @@ public interface Indexer {
 	public void addRelatedEntryFields(Document document, Object obj)
 		throws Exception;
 
+	public void contributeToFullQuery(SearchContext searchContext);
+
 	public void delete(long companyId, String uid) throws SearchException;
 
 	public void delete(Object obj) throws SearchException;

--- a/portal-service/src/com/liferay/portal/kernel/search/IndexerWrapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/IndexerWrapper.java
@@ -40,6 +40,11 @@ public class IndexerWrapper implements Indexer {
 	}
 
 	@Override
+	public void contributeToFullQuery(SearchContext searchContext) {
+		_indexer.contributeToFullQuery(searchContext);
+	}
+
+	@Override
 	public void delete(long companyId, String uid) throws SearchException {
 		_indexer.delete(companyId, uid);
 	}

--- a/portal-service/src/com/liferay/portal/kernel/search/SearchContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/SearchContext.java
@@ -24,9 +24,11 @@ import com.liferay.portal.model.Layout;
 import java.io.Serializable;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -36,12 +38,24 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class SearchContext implements Serializable {
 
+	public void addEntryClassNameForFullQuery(String entryClassName) {
+		if (_entryClassNamesForFullQuery == null) {
+			_entryClassNamesForFullQuery = new HashSet<String>();
+		}
+
+		_entryClassNamesForFullQuery.add(entryClassName);
+	}
+
 	public void addFacet(Facet facet) {
 		if (facet == null) {
 			return;
 		}
 
 		_facets.put(facet.getFieldName(), facet);
+	}
+
+	public void clearEntryClassNamesForFullQuery() {
+		_entryClassNamesForFullQuery = null;
 	}
 
 	public long[] getAssetCategoryIds() {
@@ -94,6 +108,15 @@ public class SearchContext implements Serializable {
 		}
 
 		return _entryClassNames;
+	}
+
+	public String[] getEntryClassNamesForFullQuery() {
+		if (_entryClassNamesForFullQuery == null) {
+			return new String[0];
+		}
+
+		return _entryClassNamesForFullQuery.toArray(
+			new String[_entryClassNamesForFullQuery.size()]);
 	}
 
 	public Facet getFacet(String fieldName) {
@@ -379,6 +402,7 @@ public class SearchContext implements Serializable {
 	private long _companyId;
 	private int _end = QueryUtil.ALL_POS;
 	private String[] _entryClassNames;
+	private Set<String> _entryClassNamesForFullQuery;
 	private Map<String, Facet> _facets = new ConcurrentHashMap<String, Facet>();
 	private long[] _folderIds;
 	private long[] _groupIds;

--- a/portal-service/test/unit/com/liferay/portal/kernel/search/BaseIndexerGetFullQueryTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/search/BaseIndexerGetFullQueryTest.java
@@ -20,13 +20,16 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.util.DLFileEntryIndexer;
 import com.liferay.portlet.messageboards.model.MBMessage;
+import com.liferay.portlet.messageboards.util.MBMessageIndexer;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 import javax.portlet.PortletRequest;
@@ -56,7 +59,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class BaseIndexerGetFullQueryTest extends PowerMockito {
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		setUpBooleanQueryFactory();
 		setUpJSONFactory();
 		setUpProps();
@@ -184,7 +187,7 @@ public class BaseIndexerGetFullQueryTest extends PowerMockito {
 		PropsUtil.setProps(props);
 	}
 
-	protected void setUpRegistries() {
+	protected void setUpRegistries() throws Exception {
 		Registry registry = mock(Registry.class);
 
 		when(
@@ -213,6 +216,15 @@ public class BaseIndexerGetFullQueryTest extends PowerMockito {
 		RegistryUtil.setRegistry(registry);
 
 		mockStatic(IndexerRegistryUtil.class, Mockito.CALLS_REAL_METHODS);
+
+		List<Indexer> indexers = Arrays.<Indexer>asList(
+			new DLFileEntryIndexer(), new MBMessageIndexer());
+
+		PowerMockito.when(
+			IndexerRegistryUtil.class, "getIndexers"
+		).thenReturn(
+			indexers
+		);
 	}
 
 	protected void setUpSearchEngine() {


### PR DESCRIPTION
Hi @rotty3000!

This PR is for the **Search** subsystem. Together with [this one](https://github.com/sergiogonzalez/liferay-portal/pull/1440) they wipe out every single instanceof-like reference to `MBMessage.class` from Search core classes, extracting them out to the MBMessageIndexer -- ready to modularize away.

Please send back to me or forward to @sergiogonzalez at your discretion.

(Already has the contributions from @marcellustavares review.)
