### PR TITLE
[TECHNICAL-SUPPORT] LPS-50622 Time.getRelativeTimeDescription uses hard-coded formatter to provide Date string

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/Time.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Time.java
@@ -175,7 +175,8 @@ public class Time {
 	}
 
 	public static String getRelativeTimeDescription(
-		long milliseconds, Locale locale, TimeZone timeZone) {
+		long milliseconds, Format dateTimeFormat, Locale locale,
+		TimeZone timeZone) {
 
 		Format timeFormat = FastDateFormatFactoryUtil.getTime(locale, timeZone);
 
@@ -206,10 +207,18 @@ public class Time {
 				false);
 		}
 
-		Format dateFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(
-			"EEEE, MMMMM dd, yyyy", locale, timeZone);
+		if (dateTimeFormat == null) {
+			dateTimeFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(
+				"EEEE, MMMMM dd, yyyy", locale, timeZone);
+		}
 
-		return dateFormat.format(milliseconds);
+		return dateTimeFormat.format(milliseconds);
+	}
+
+	public static String getRelativeTimeDescription(
+		long milliseconds, Locale locale, TimeZone timeZone) {
+
+		return getRelativeTimeDescription(milliseconds, null, locale, timeZone);
 	}
 
 	public static String getRFC822() {


### PR DESCRIPTION
Hello Ray,

Could you please check this pull request?

Thank you!

Best regards,
István
