### PR TITLE
LPS-53132

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
@@ -548,7 +548,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 		sb.append("(((InlineSQLResourcePermission.primKey = CAST_TEXT(");
 		sb.append(classPKField);
-		sb.append(")) AND ((");
+		sb.append(")) AND (");
 
 		boolean hasPreviousViewableGroup = false;
 
@@ -587,11 +587,16 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			}
 		}
 
-		sb.append(StringPool.CLOSE_PARENTHESIS);
-
 		if (!viewableGroupIds.isEmpty()) {
 			for (Long viewableGroupId : viewableGroupIds) {
-				sb.append(" OR (");
+
+				if (hasPreviousViewableGroup) {
+					sb.append(" OR ");
+				}
+
+				hasPreviousViewableGroup = true;
+
+				sb.append(StringPool.OPEN_PARENTHESIS);
 
 				if (Validator.isNull(groupIdField)) {
 					sb.append(

--- a/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
@@ -27,9 +27,7 @@ import com.liferay.portal.service.ResourceTypePermissionLocalServiceUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**

--- a/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
@@ -550,60 +550,32 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		sb.append(classPKField);
 		sb.append(")) AND (");
 
-		boolean hasPreviousViewableGroup = false;
+		boolean hasPreviousGroup = false;
 
 		for (int j = 0; j < groupIds.length; j++) {
 			long groupId = groupIds[j];
 
-			if (!permissionChecker.hasPermission(
-					groupId, className, 0, ActionKeys.VIEW)) {
+			if ((j > 0) && hasPreviousGroup) {
+				sb.append(" OR ");
+			}
 
-				if ((j > 0) && hasPreviousViewableGroup) {
-					sb.append(" OR ");
-				}
+			hasPreviousGroup = true;
 
-				hasPreviousViewableGroup = true;
+			sb.append(StringPool.OPEN_PARENTHESIS);
 
-				sb.append(StringPool.OPEN_PARENTHESIS);
-
-				if (Validator.isNull(groupIdField)) {
-					sb.append(
-						classPKField.substring(
-							0, classPKField.lastIndexOf(CharPool.PERIOD)));
-					sb.append(".groupId = ");
-				}
-				else {
-					sb.append(groupIdField);
-					sb.append(" = ");
-				}
-
-				sb.append(groupId);
-				sb.append(StringPool.CLOSE_PARENTHESIS);
+			if (Validator.isNull(groupIdField)) {
+				sb.append(
+					classPKField.substring(
+						0, classPKField.lastIndexOf(CharPool.PERIOD)));
+				sb.append(".groupId = ");
 			}
 			else {
-
-				if (hasPreviousViewableGroup) {
-					sb.append(" OR ");
-				}
-
-				hasPreviousViewableGroup = true;
-
-				sb.append(StringPool.OPEN_PARENTHESIS);
-
-				if (Validator.isNull(groupIdField)) {
-					sb.append(
-						classPKField.substring(
-							0, classPKField.lastIndexOf(CharPool.PERIOD)));
-					sb.append(".groupId = ");
-				}
-				else {
-					sb.append(groupIdField);
-					sb.append(" = ");
-				}
-
-				sb.append(groupId);
-				sb.append(StringPool.CLOSE_PARENTHESIS);
+				sb.append(groupIdField);
+				sb.append(" = ");
 			}
+
+			sb.append(groupId);
+			sb.append(StringPool.CLOSE_PARENTHESIS);
 		}
 
 		sb.append(")))");

--- a/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
@@ -552,8 +552,6 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 		boolean hasPreviousViewableGroup = false;
 
-		List<Long> viewableGroupIds = new ArrayList<>();
-
 		for (int j = 0; j < groupIds.length; j++) {
 			long groupId = groupIds[j];
 
@@ -583,12 +581,6 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 			else {
-				viewableGroupIds.add(groupId);
-			}
-		}
-
-		if (!viewableGroupIds.isEmpty()) {
-			for (Long viewableGroupId : viewableGroupIds) {
 
 				if (hasPreviousViewableGroup) {
 					sb.append(" OR ");
@@ -609,7 +601,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 					sb.append(" = ");
 				}
 
-				sb.append(viewableGroupId);
+				sb.append(groupId);
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 		}


### PR DESCRIPTION
This pull request avoids a malformed SQL with a empty "()" in some situations: 
   `....peId)) AND (() OR (dlFileEn.....`
See first commit https://github.com/jorgediaz-lr/liferay-portal/commit/d344e7b9ce5b81841cde2cd0e3c579dafd586a91

After this modification, I have realized that there is some unnecessary code:
      - The permission check is not necessary because both if and else code are the same
      - This code was modified at following issues: LPS-43611, LPS-45001, where some different code was removed at IF side

I have simplified the code at the rest of commits
