### PR TITLE
LPS-52392 Apply group by clause to avoid duplicates

### DIFF
--- a/portal-impl/src/custom-sql/dynamicdatamapping.xml
+++ b/portal-impl/src/custom-sql/dynamicdatamapping.xml
@@ -4,7 +4,7 @@
 	<sql id="com.liferay.portlet.dynamicdatamapping.service.persistence.DDMStructureFinder.countByC_G_C_N_D_S_T">
 		<![CDATA[
 			SELECT
-				COUNT(DISTINCT structureId) AS COUNT_VALUE
+				COUNT(DDMStructure.structureId) AS COUNT_VALUE
 			FROM
 				DDMStructure
 			WHERE
@@ -22,7 +22,7 @@
 	<sql id="com.liferay.portlet.dynamicdatamapping.service.persistence.DDMStructureFinder.findByC_G_C_N_D_S_T">
 		<![CDATA[
 			SELECT
-				DISTINCT {DDMStructure.*}
+				{DDMStructure.*}
 			FROM
 				DDMStructure
 			WHERE
@@ -42,7 +42,7 @@
 	<sql id="com.liferay.portlet.dynamicdatamapping.service.persistence.DDMTemplateFinder.countByG_C_SC">
 		<![CDATA[
 			SELECT
-				COUNT(DISTINCT templateId) AS COUNT_VALUE
+				COUNT(DDMTemplate.templateId) AS COUNT_VALUE
 			FROM
 				DDMTemplate
 			WHERE
@@ -64,7 +64,7 @@
 	<sql id="com.liferay.portlet.dynamicdatamapping.service.persistence.DDMTemplateFinder.countByC_G_C_C_N_D_T_M_L">
 		<![CDATA[
 			SELECT
-				COUNT(DISTINCT templateId) AS COUNT_VALUE
+				COUNT(DDMTemplate.templateId) AS COUNT_VALUE
 			FROM
 				DDMTemplate
 			WHERE
@@ -84,7 +84,7 @@
 	<sql id="com.liferay.portlet.dynamicdatamapping.service.persistence.DDMTemplateFinder.findByG_C_SC">
 		<![CDATA[
 			SELECT
-				DISTINCT {DDMTemplate.*}
+				{DDMTemplate.*}
 			FROM
 				DDMTemplate
 			WHERE
@@ -108,7 +108,7 @@
 	<sql id="com.liferay.portlet.dynamicdatamapping.service.persistence.DDMTemplateFinder.findByC_G_C_C_N_D_T_M_L">
 		<![CDATA[
 			SELECT
-				DISTINCT {DDMTemplate.*}
+				{DDMTemplate.*}
 			FROM
 				DDMTemplate
 			WHERE

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -53,6 +53,8 @@
 						(ResourcePermission.scope = [$RESOURCE_SCOPE_INDIVIDUAL$]) AND
 						(MOD(ResourcePermission.actionIds, 2) = 1) AND
 						[$ROLE_IDS_OR_OWNER_ID$]
+					GROUP BY
+						primKey
 				)
 			InlineSQLResourcePermission ON
 				[$PRIM_KEYS$]


### PR DESCRIPTION
Hey Ray,

This a fix for what has being discussed on https://github.com/brianchandotcom/liferay-portal/pull/20091#event-146358495.

Basically we've applied DISTINCT on DDM queries (https://github.com/ealonso/liferay-portal/commit/b6072f09c9bd26dee9a21c6dc020c395ca4bc3f1 and https://github.com/ealonso/liferay-portal/commit/fe73b6d5eb75d86ad781a57ab08925c12e69128d) to solve the problem described on LPS-46114.

I've rolled them back and applied the fix on InlineSQL join clause which causes the duplication.

Let me know if that sounds good to you.

Thanks
