### PR TITLE
LPS-53451 varchar(750) is insufficient for localized contents, using 4000 on DB2 like Oracle

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/DB2DB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/DB2DB.java
@@ -276,7 +276,7 @@ public class DB2DB extends BaseDB {
 	private static final String[] _DB2 = {
 		"--", "1", "0", "'1970-01-01-00.00.00.000000'", "current timestamp",
 		" blob", " blob", " smallint", " timestamp", " double", " integer",
-		" bigint", " varchar(750)", " clob", " varchar",
+		" bigint", " varchar(4000)", " clob", " varchar",
 		" generated always as identity", "commit"
 	};
 


### PR DESCRIPTION
Hi Ray, this is safer. Changing the column type could cause issues with some SQL operators.

Thanks