### PR TITLE
LPS-53825 Friendly URL beginning with the same string as proxy path is filtered wrong

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -167,12 +167,6 @@ public class VirtualHostFilter extends BasePortalFilter {
 
 		String friendlyURL = originalFriendlyURL;
 
-		if (Validator.isNotNull(contextPath) &&
-			friendlyURL.contains(contextPath)) {
-
-			friendlyURL = friendlyURL.substring(contextPath.length());
-		}
-
 		int pos = friendlyURL.indexOf(StringPool.SEMICOLON);
 
 		if (pos != -1) {


### PR DESCRIPTION
Hi Ray,

we are really not sure if this modification can be done without any side-effect, however, we cannot see which that code snippet is necessary; our tests don't show any problem.

It could be a case only if the friendly url contains the context path which, I think, shouldn't be a case, however I might be wrong. Might that be there because of some legacy case? Nevertheless, it definitely cause a problem in the latest versions if the friendly url of a page starts with the context path in its name.

Could you please take a look at.

Thank yin advance,
Zsigmond