### PR TITLE
LPS-53912 Convert PyObjectDerived to java.lang.Object to make it possible to cast it to the proper Java type

### DIFF
--- a/portal-impl/src/com/liferay/portal/scripting/python/PythonExecutor.java
+++ b/portal-impl/src/com/liferay/portal/scripting/python/PythonExecutor.java
@@ -73,7 +73,9 @@ public class PythonExecutor extends BaseScriptingExecutor {
 
 		for (String outputName : outputNames) {
 			outputObjects.put(
-				outputName, interactiveInterpreter.get(outputName));
+				outputName,
+				interactiveInterpreter.get(
+					outputName).__tojava__(Object.class));
 		}
 
 		return outputObjects;


### PR DESCRIPTION
Hi Ray,

This fix is pretty simple and the script for testing on the LPS can demonstrate the problem.
Please review my change and let me know if you have any concerns or questions.

Regards,
Vilmos