### PR TITLE
LPS-53875 the defaultPreferences attribute is ignored by the liferay-portlet:runtime tag when the portlet is instantiable and it is placed in a regular page of a site

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -171,6 +171,13 @@ public class PortletPreferencesFactoryImpl
 	public PortletPreferences getLayoutPortletSetup(
 		Layout layout, String portletId) {
 
+		return getLayoutPortletSetup(layout, portletId, null);
+	}
+
+	@Override
+	public PortletPreferences getLayoutPortletSetup(
+		Layout layout, String portletId, String defaultPreferences) {
+
 		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
 		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
 
@@ -181,7 +188,7 @@ public class PortletPreferencesFactoryImpl
 
 		return PortletPreferencesLocalServiceUtil.getPreferences(
 			layout.getCompanyId(), ownerId, ownerType, layout.getPlid(),
-			portletId);
+			portletId, defaultPreferences);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portlet/PortletPreferencesFactory.java
+++ b/portal-service/src/com/liferay/portlet/PortletPreferencesFactory.java
@@ -59,6 +59,9 @@ public interface PortletPreferencesFactory {
 	public PortletPreferences getLayoutPortletSetup(
 		Layout layout, String portletId);
 
+	public PortletPreferences getLayoutPortletSetup(
+		Layout layout, String portletId, String defaultPreferences);
+
 	public PortalPreferences getPortalPreferences(HttpServletRequest request);
 
 	public PortalPreferences getPortalPreferences(

--- a/portal-service/src/com/liferay/portlet/PortletPreferencesFactoryUtil.java
+++ b/portal-service/src/com/liferay/portlet/PortletPreferencesFactoryUtil.java
@@ -82,6 +82,13 @@ public class PortletPreferencesFactoryUtil {
 			layout, portletId);
 	}
 
+	public static PortletPreferences getLayoutPortletSetup(
+		Layout layout, String portletId, String defaultPreferences) {
+
+		return getPortletPreferencesFactory().getLayoutPortletSetup(
+			layout, portletId, defaultPreferences);
+	}
+
 	public static PortalPreferences getPortalPreferences(
 		HttpServletRequest request) {
 

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -202,7 +202,7 @@ public class RuntimeTag extends TagSupport {
 				layout.isTypeControlPanel() || layout.isTypePanel()) {
 
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-					layout, portletId);
+					layout, portletId, defaultPreferences);
 				PortletPreferencesFactoryUtil.getPortletSetup(
 					request, portletId, defaultPreferences);
 


### PR DESCRIPTION
cc @jorgeFerrer