### PR TITLE
Add support to start bundles which the spring files defined in "spring.infrastructure.configs" depend on.

### DIFF
--- a/modules/core/portal-bootstrap/src/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -286,6 +286,15 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		bundleStartLevel.setStartLevel(startLevel);
 	}
 
+	@Override
+	public void startAutoDeploy() throws Exception {
+		for (String initialBundle :
+				PropsValues.MODULE_FRAMEWORK_REQUIRED_BUNDLES) {
+
+			_installInitialBundle(initialBundle, "static");
+		}
+	}
+
 	public void startBundle(
 			Bundle bundle, int options, boolean checkPermissions)
 		throws PortalException {
@@ -332,7 +341,11 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 
 		_setUpPrerequisiteFrameworkServices(_framework.getBundleContext());
 
-		_setUpInitialBundles();
+		for (String initialBundle :
+				PropsValues.MODULE_FRAMEWORK_INITIAL_BUNDLES) {
+
+			_installInitialBundle(initialBundle, "portal");
+		}
 	}
 
 	@Override
@@ -680,7 +693,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		return false;
 	}
 
-	private void _installInitialBundle(String location) {
+	private void _installInitialBundle(String location, String subCategory) {
 		boolean start = false;
 		int startLevel = PropsValues.MODULE_FRAMEWORK_BEGINNING_START_LEVEL;
 
@@ -708,7 +721,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 			if (!location.startsWith("file:")) {
 				location =
 					"file:" + PropsValues.MODULE_FRAMEWORK_BASE_DIR +
-						"/static/" + location;
+						"/" + subCategory + "/" + location;
 			}
 
 			URL initialBundleURL = new URL(location);
@@ -841,14 +854,6 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		bundleContext.registerService(
 			new String[] {ServletContext.class.getName()}, servletContext,
 			_getProperties(servletContext, "liferayServletContext"));
-	}
-
-	private void _setUpInitialBundles() throws Exception {
-		for (String initialBundle :
-				PropsValues.MODULE_FRAMEWORK_INITIAL_BUNDLES) {
-
-			_installInitialBundle(initialBundle);
-		}
 	}
 
 	private void _setUpPrerequisiteFrameworkServices(

--- a/modules/core/portal-bootstrap/src/com/liferay/portal/bootstrap/ModuleFrameworkUtil.java
+++ b/modules/core/portal-bootstrap/src/com/liferay/portal/bootstrap/ModuleFrameworkUtil.java
@@ -70,6 +70,10 @@ public class ModuleFrameworkUtil {
 		_moduleFramework = moduleFramework;
 	}
 
+	public static void startAutoDeploy() throws Exception {
+		getModuleFramework().startAutoDeploy();
+	}
+
 	public static void startBundle(long bundleId) throws PortalException {
 		getModuleFramework().startBundle(bundleId);
 	}

--- a/modules/portal/portal-dummy/.classpath
+++ b/modules/portal/portal-dummy/.classpath
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<classpath>
+	<classpathentry excluding="**/.svn/**|.svn/" kind="src" path="src" />
+	<classpathentry kind="src" path="/portal-master" />
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/bnd.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-logging.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/log4j.jar" />
+	<classpathentry kind="lib" path="/portal-master/portal-service/portal-service.jar" />
+	<classpathentry kind="lib" path="lib/org.osgi.compendium.jar" />
+	<classpathentry kind="lib" path="lib/org.osgi.core.jar" />
+	<classpathentry kind="output" path="bin" />
+</classpath>

--- a/modules/portal/portal-dummy/.project
+++ b/modules/portal/portal-dummy/.project
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<projectDescription>
+	<name>portal-dummy</name>
+	<comment></comment>
+	<projects></projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments></arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/modules/portal/portal-dummy/bnd.bnd
+++ b/modules/portal/portal-dummy/bnd.bnd
@@ -1,0 +1,9 @@
+Bundle-Activator: com.liferay.portal.dummy.DummyActivator
+Bundle-Name: Liferay Portal Dummy
+Bundle-SymbolicName: com.liferay.portal.dummy
+Bundle-Version: 1.0.0
+Import-Package:\
+	*
+Include-Resource:\
+	classes
+

--- a/modules/portal/portal-dummy/build.xml
+++ b/modules/portal/portal-dummy/build.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../tools/sdk/build-common-osgi-plugin.xml" />
+
+	<property name="auto.deploy.dir" value="${liferay.home}/osgi/portal" />
+</project>

--- a/modules/portal/portal-dummy/ivy.xml
+++ b/modules/portal/portal-dummy/ivy.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<ivy-module
+	version="2.0"
+	xmlns:m2="http://ant.apache.org/ivy/maven"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd"
+>
+	<info module="${plugin.name}" organisation="com.liferay">
+		<extends extendType="configurations,description,info" location="${sdk.dir}/ivy.xml" module="com.liferay.sdk" organisation="com.liferay" revision="latest.integration" />
+	</info>
+
+	<publications>
+		<artifact type="jar" />
+		<artifact type="pom" />
+		<artifact m2:classifier="sources" />
+	</publications>
+
+	<dependencies defaultconf="default">
+		<dependency name="org.osgi.compendium" org="org.osgi" rev="5.0.0" />
+		<dependency name="org.osgi.core" org="org.osgi" rev="5.0.0" />
+	</dependencies>
+</ivy-module>
+

--- a/modules/portal/portal-dummy/src/com/liferay/portal/dummy/DummyActivator.java
+++ b/modules/portal/portal-dummy/src/com/liferay/portal/dummy/DummyActivator.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+package com.liferay.portal.dummy;
+
+import com.liferay.portal.kernel.cache.PortalCache;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author Tina Tian
+ */
+public class DummyActivator implements BundleActivator {
+
+	public void start(BundleContext bundleContext) {
+		bundleContext.registerService(
+			PortalCache.class.getName(), new DummyCache(), null);
+	}
+
+	public void stop(BundleContext bundleContext) {}
+	
+}

--- a/modules/portal/portal-dummy/src/com/liferay/portal/dummy/DummyCache.java
+++ b/modules/portal/portal-dummy/src/com/liferay/portal/dummy/DummyCache.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dummy;
+
+import com.liferay.portal.kernel.cache.CacheListener;
+import com.liferay.portal.kernel.cache.CacheListenerScope;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.cache.PortalCacheManager;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author Tina Tian
+ */
+public class DummyCache implements PortalCache<Serializable, Serializable>{
+
+	@Override
+	public Serializable get(Serializable k) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public List<Serializable> getKeys() {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public String getName() {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public PortalCacheManager<Serializable, Serializable> getPortalCacheManager() {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void put(Serializable k, Serializable v) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void put(Serializable k, Serializable v, int i) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void registerCacheListener(CacheListener<Serializable, Serializable> cl) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void registerCacheListener(CacheListener<Serializable, Serializable> cl, CacheListenerScope cls) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void remove(Serializable k) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void removeAll() {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void unregisterCacheListener(CacheListener<Serializable, Serializable> cl) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void unregisterCacheListeners() {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/module/framework/ModuleFramework.java
+++ b/portal-impl/src/com/liferay/portal/module/framework/ModuleFramework.java
@@ -40,6 +40,8 @@ public interface ModuleFramework {
 	public void setBundleStartLevel(long bundleId, int startLevel)
 		throws PortalException;
 
+	public void startAutoDeploy() throws Exception;
+
 	public void startBundle(long bundleId) throws PortalException;
 
 	public void startBundle(long bundleId, int options) throws PortalException;

--- a/portal-impl/src/com/liferay/portal/module/framework/ModuleFrameworkUtilAdapter.java
+++ b/portal-impl/src/com/liferay/portal/module/framework/ModuleFrameworkUtilAdapter.java
@@ -79,6 +79,10 @@ public class ModuleFrameworkUtilAdapter {
 			_moduleFramework);
 	}
 
+	public static void startAutoDeploy() throws Exception {
+		_moduleFramework.startAutoDeploy();
+	}
+
 	public static void startBundle(long bundleId) throws PortalException {
 		_moduleFramework.startBundle(bundleId);
 	}

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -237,6 +237,8 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		try {
 			ModuleFrameworkUtilAdapter.initFramework();
 
+			ModuleFrameworkUtilAdapter.startFramework();
+
 			_arrayApplicationContext = new ArrayApplicationContext(
 				PropsValues.SPRING_INFRASTRUCTURE_CONFIGS);
 
@@ -247,7 +249,7 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 			ModuleFrameworkUtilAdapter.registerContext(
 				_arrayApplicationContext);
 
-			ModuleFrameworkUtilAdapter.startFramework();
+			ModuleFrameworkUtilAdapter.startAutoDeploy();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1148,6 +1148,8 @@ public class PropsValues {
 
 	public static final String[] MODULE_FRAMEWORK_INITIAL_BUNDLES = PropsUtil.getArray(PropsKeys.MODULE_FRAMEWORK_INITIAL_BUNDLES);
 
+	public static final String[] MODULE_FRAMEWORK_REQUIRED_BUNDLES = PropsUtil.getArray(PropsKeys.MODULE_FRAMEWORK_REQUIRED_BUNDLES);
+
 	public static final String MODULE_FRAMEWORK_PORTAL_DIR = PropsUtil.get(PropsKeys.MODULE_FRAMEWORK_PORTAL_DIR);
 
 	public static final boolean MODULE_FRAMEWORK_REGISTER_LIFERAY_SERVICES = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.MODULE_FRAMEWORK_REGISTER_LIFERAY_SERVICES));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7284,7 +7284,8 @@
     # Set a comma delimited list of OSGi bundles that are automatically installed
     # and started once the system is up and running.
     #
-    module.framework.initial.bundles=
+    module.framework.initial.bundles=\
+		com.liferay.portal.dummy.jar@start
 
     #
     # Set a comma delimited list of OSGi bundles that are required to deploy

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7282,9 +7282,15 @@
 
     #
     # Set a comma delimited list of OSGi bundles that are automatically installed
-    # and optionally started once the system is up and running.
+    # and started once the system is up and running.
     #
-    module.framework.initial.bundles=\
+    module.framework.initial.bundles=
+
+    #
+    # Set a comma delimited list of OSGi bundles that are required to deploy
+    # bundles automatically.
+    #
+    module.framework.required.bundles=\
         org.apache.felix.configadmin.jar@start,\
         org.apache.felix.fileinstall.jar@start
 

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1693,6 +1693,8 @@ public interface PropsKeys {
 
 	public static final String MODULE_FRAMEWORK_REGISTER_LIFERAY_SERVICES = "module.framework.register.liferay.services";
 
+	public static final String MODULE_FRAMEWORK_REQUIRED_BUNDLES = "module.framework.required.bundles";
+
 	public static final String MODULE_FRAMEWORK_RUNTIME_START_LEVEL = "module.framework.runtime.start.level";
 
 	public static final String MODULE_FRAMEWORK_SERVICES_IGNORED_INTERFACES = "module.framework.services.ignored.interfaces";


### PR DESCRIPTION
@mhan810 @shuyangzhou

Hi Ray,

I met a problem about the order of starting osgi bundles while trying to extract ehcache as a bundle. 

The problem is some bundles need to be started, or in other words, some services need to be registered, before the spring files setting in "spring.infrastructure.configs" are parsed, since some spring beans defined in those files depend on the bundle services.

In this pull request, I modified the order we start bundles, but I am not sure if it is safe to do this or if you are OK with this solution.  Could you please take a look at it? 

This pull request is only a rough version to confirm with you if those changes are OK, I will send you a formal one later.

And I also tried to initialize spring files in "spring.infrastructure.configs" after osgi framework is started, some exceptions came up, I think you should have a good reason to initialize those before framework is started, right?


Thanks.
Tina.