### PR TITLE
LPS-55290 Vary: Accept-Encoding should not be set for certain content

### DIFF
--- a/portal-impl/src/com/liferay/portal/deploy/dependencies/speed-filters-web.xml
+++ b/portal-impl/src/com/liferay/portal/deploy/dependencies/speed-filters-web.xml
@@ -101,6 +101,10 @@
 		<param-name>filter-class</param-name>
 		<param-value>com.liferay.portal.servlet.filters.gzip.GZipFilter</param-value>
 	</init-param>
+	<init-param>
+		<param-name>Vary</param-name>
+		<param-value>Accept-Encoding</param-value>
+	</init-param>
 </filter>
 <filter>
 	<filter-name>GZip Filter - Theme PNG</filter-name>
@@ -112,6 +116,10 @@
 	<init-param>
 		<param-name>url-regex-pattern</param-name>
 		<param-value>.+/themes/.*/images/.*\.png</param-value>
+	</init-param>
+	<init-param>
+		<param-name>Vary</param-name>
+		<param-value>Accept-Encoding</param-value>
 	</init-param>
 </filter>
 <filter>
@@ -132,10 +140,6 @@
 	<init-param>
 		<param-name>Expires</param-name>
 		<param-value>315360000</param-value>
-	</init-param>
-	<init-param>
-		<param-name>Vary</param-name>
-		<param-value>Accept-Encoding</param-value>
 	</init-param>
 </filter>
 <filter>

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -136,6 +136,10 @@
 			<param-name>url-regex-ignore-pattern</param-name>
 			<param-value>^(/c/document_library/get_file|/c/message_boards/get_message_attachment|/c/wiki/get_page_attachment)(\?.*)?$</param-value>
 		</init-param>
+		<init-param>
+			<param-name>Vary</param-name>
+			<param-value>Accept-Encoding</param-value>
+		</init-param>
 	</filter>
 	<filter>
 		<filter-name>GZip Filter - Theme PNG</filter-name>
@@ -143,6 +147,10 @@
 		<init-param>
 			<param-name>url-regex-pattern</param-name>
 			<param-value>.+/themes/.*/images/.*\.png</param-value>
+		</init-param>
+		<init-param>
+			<param-name>Vary</param-name>
+			<param-value>Accept-Encoding</param-value>
 		</init-param>
 	</filter>
 	<filter>
@@ -159,10 +167,6 @@
 		<init-param>
 			<param-name>Expires</param-name>
 			<param-value>315360000</param-value>
-		</init-param>
-		<init-param>
-			<param-name>Vary</param-name>
-			<param-value>Accept-Encoding</param-value>
 		</init-param>
 	</filter>
 	<filter>


### PR DESCRIPTION
Hi Ray,

Currently the portal is adding a **Vary: Accept-Encoding** in the header for image binaries. This is not correct as binaries will never have their encoding vary as there is no point in trying to compress them.

In this specific use-case, the caching layer at content delivery service provider never caches the image resource because the corresponding response header Content-Encoding is never sent (since images are never re-encoded).

Thanks for reviewing!

Cheers,
László