### PR TITLE
LPS-55431 add TRACE log level to Levels.java

### DIFF
--- a/util-java/src/com/liferay/util/log4j/Levels.java
+++ b/util-java/src/com/liferay/util/log4j/Levels.java
@@ -23,7 +23,7 @@ public class Levels {
 
 	public static final Level[] ALL_LEVELS = new Level[] {
 		Level.OFF, Level.FATAL, Level.ERROR, Level.WARN, Level.INFO,
-		Level.DEBUG, Level.ALL
+		Level.DEBUG, Level.TRACE, Level.ALL
 	};
 
 }


### PR DESCRIPTION
Hi Ray,

This is just a simple one-liner. The thing is that we've got the trace() call in our logging API, but on the admin UI you can see only DEBUG and ALL, TRACE isn't displayed.

The available API methods and the possible log levels in com.liferay.util.log4j.Levels wasn't aligned.

Thanks for reviewing!

Cheers,
László