### PR TITLE
LPS-57926 Get layout group before checking if it is the personal site

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -547,16 +547,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			if (groupId > 0) {
 				group = GroupLocalServiceUtil.getGroup(groupId);
 
-				// If the group is a personal site, check the "User Personal
-				// Site" group.
-
-				if (group.isUser() && (group.getClassPK() == getUserId())) {
-					group = GroupLocalServiceUtil.getGroup(
-						getCompanyId(), GroupConstants.USER_PERSONAL_SITE);
-
-					groupId = group.getGroupId();
-				}
-
 				// If the group is a scope group for a layout, check the
 				// original group.
 
@@ -569,6 +559,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					groupId = layout.getGroupId();
 
 					group = GroupLocalServiceUtil.getGroup(groupId);
+				}
+
+				// If the group is a personal site, check the "User Personal
+				// Site" group.
+
+				if (group.isUser() && (group.getClassPK() == getUserId())) {
+					group = GroupLocalServiceUtil.getGroup(
+						getCompanyId(), GroupConstants.USER_PERSONAL_SITE);
+
+					groupId = group.getGroupId();
 				}
 
 				// If the group is a staging group, check the live group.


### PR DESCRIPTION
Hi @rotty3000,

This PR fixes permission checking for page scoped portlets in a user's personal site.

The check for the USER_PERSONAL_SITE was performed before getting the layout enclosing group, and permissions were always checked with the wrong groupId.

Thanks!