### PR TITLE
 LPS-58509 Navigating to Configuration Admin throws NPE

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-web/bnd.bnd
@@ -4,6 +4,7 @@ Bundle-Version: 1.0.0
 Import-Package:\
 	com.liferay.dynamic.data.mapping.form.renderer,\
 	com.liferay.dynamic.data.mapping.form.values.factory,\
+	com.liferay.portal.portlet.tracker,\
 	*
 Include-Resource:\
 	classes,\

--- a/modules/apps/configuration-admin/configuration-admin-web/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-web/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-renderer")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-values-factory")
+	compile project(":portal:portal-portlet-tracker")
 
 	testCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.test.util", version: "1.0.0-SNAPSHOT"
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/util/ConfigurationAdminCustomUserAttributes.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/util/ConfigurationAdminCustomUserAttributes.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.web.util;
+
+import com.liferay.configuration.admin.web.constants.ConfigurationAdminPortletKeys;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.portlet.tracker.PortletTrackerDependency;
+import com.liferay.portlet.CustomUserAttributes;
+import com.liferay.portlet.DefaultCustomUserAttributes;
+import com.liferay.portlet.PortletContextBag;
+import com.liferay.portlet.PortletContextBagPool;
+
+import java.util.Dictionary;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Peter Fellwock
+ */
+@Component(
+	immediate = true,
+	property = {
+			"javax.portlet.name=" + ConfigurationAdminPortletKeys.CONFIGURATION_ADMIN
+	},
+	service = CustomUserAttributes.class
+)
+public class ConfigurationAdminCustomUserAttributes
+	extends DefaultCustomUserAttributes {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		Bundle bundle = bundleContext.getBundle();
+
+		PortletContextBag portletContextBag = PortletContextBagPool.get(
+			getServletContextName(bundle));
+
+		if (portletContextBag == null) {
+			portletContextBag = new PortletContextBag(
+				getServletContextName(bundle));
+		}
+
+		portletContextBag.getCustomUserAttributes().put(
+			DefaultCustomUserAttributes.class.getName(), this);
+	}
+
+	protected String getServletContextName(Bundle bundle) {
+		Dictionary<String, String> headers = bundle.getHeaders();
+
+		String header = headers.get("Servlet-Context-Name");
+
+		if (Validator.isNotNull(header)) {
+			return header;
+		}
+
+		String symbolicName = bundle.getSymbolicName();
+
+		return symbolicName.replaceAll("[^a-zA-Z0-9]", "");
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortletTracker(
+		PortletTrackerDependency portletTrackerDependency) {
+
+		_portletTrackerDependency = portletTrackerDependency;
+	}
+
+	private PortletTrackerDependency _portletTrackerDependency;
+
+}

--- a/modules/portal/portal-portlet-tracker/bnd.bnd
+++ b/modules/portal/portal-portlet-tracker/bnd.bnd
@@ -6,6 +6,7 @@ Import-Package:\
 	javax.servlet;version='[2.3.0,4.0.0)',\
 	javax.servlet.http;version='[2.3.0,4.0.0)',\
 	*
+Export-Package: com.liferay.portal.portlet.tracker
 Include-Resource:\
 	classes,\
 	@${app.server.lib.portal.dir}/util-java.jar!/com/liferay/util/log4j/Log4JUtil.class

--- a/modules/portal/portal-portlet-tracker/src/com/liferay/portal/portlet/tracker/PortletTrackerDependency.java
+++ b/modules/portal/portal-portlet-tracker/src/com/liferay/portal/portlet/tracker/PortletTrackerDependency.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portlet.tracker;
+
+import com.liferay.portal.portlet.tracker.internal.PortletTracker;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Peter Fellwock
+ */
+@Component(immediate = true, service = PortletTrackerDependency.class)
+public class PortletTrackerDependency {
+
+	@Reference(unbind = "-")
+	protected void setPortletTracker(PortletTracker portletTracker) {
+		_portletTracker = portletTracker;
+	}
+
+	private PortletTracker _portletTracker;
+
+}

--- a/modules/portal/portal-portlet-tracker/src/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
+++ b/modules/portal/portal-portlet-tracker/src/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
@@ -298,11 +298,16 @@ public class PortletTracker
 		collectJxPortletFeatures(serviceReference, portletModel);
 		collectLiferayFeatures(serviceReference, portletModel);
 
-		PortletContextBag portletContextBag = new PortletContextBag(
+		PortletContextBag portletContextBag = PortletContextBagPool.get(
 			bundlePortletApp.getServletContextName());
 
-		PortletContextBagPool.put(
-			bundlePortletApp.getServletContextName(), portletContextBag);
+		if (portletContextBag == null) {
+			portletContextBag = new PortletContextBag(
+				bundlePortletApp.getServletContextName());
+
+			PortletContextBagPool.put(
+				bundlePortletApp.getServletContextName(), portletContextBag);
+		}
 
 		PortletBagFactory portletBagFactory = new BundlePortletBagFactory(
 			portlet);


### PR DESCRIPTION
In order to inject the CustomUserAttributes into the PortletBag -> PortletContextBagPool for ConfigurationAdmin I created (like you suggested) a Component that at @Activate will do this. The issue I found was that when ConfigurationAdmin initializes before the PortletTracker module loads, therefore I ended up with two PortletContextBagPool singleton instances. Therefore I created a "PortletTrackerDependency" OSGi component in PortletTracker that is then referenced in ConfigurationAdmin, thus forcing ConfigurationAdmin to wait for PortletTracker to init. The issue is the naming convention that @brianchandotcom and I have been working on trying to figure out. 

Inconsistent issues:
1. PortletTracker lives in an "internal" package, but looking at *Tracker.java, some live in internal packages and others do not.
2. There is no pattern for *Dependency.java, so this would be a new pattern, @brianchandotcom originally suggested using the PortletTracker/PortletTrackerImpl pattern but that still does not solve the issue since PortletTracker would be an interface which cannot be made into a @Component.

My suggestion is to create a new pattern where "internal" classes can be exposed by means of a Dependency component = "UnSharableClass"Dependency. If you have a better pattern or name for Dependency (Holder, Waiter, Stub, WaitOnMe) please let me know, I will make the change and re-send to @brianchandotcom.
