### PR TITLE
LPS-57826 Permissions and Staging

### DIFF
--- a/portal-impl/src/META-INF/staging-spring.xml
+++ b/portal-impl/src/META-INF/staging-spring.xml
@@ -10,9 +10,15 @@
 >
 	<bean id="com.liferay.portal.model.adapter.builder.StagedGroupModelAdapterBuilder" class="com.liferay.portal.model.adapter.builder.StagedGroupModelAdapterBuilder" />
 	<bean id="com.liferay.portal.model.adapter.builder.StagedThemeModelAdapterBuilder" class="com.liferay.portal.model.adapter.builder.StagedThemeModelAdapterBuilder" />
+	<bean id="com.liferay.portal.service.impl.GroupLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.GroupLocalServiceStagingAdvice" />
 	<bean id="com.liferay.portal.service.impl.LayoutLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.LayoutLocalServiceStagingAdvice" />
 	<bean id="com.liferay.portal.service.impl.LayoutSetLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.LayoutSetLocalServiceStagingAdvice" />
 	<bean id="com.liferay.portal.service.impl.PortletPreferencesLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.PortletPreferencesLocalServiceStagingAdvice" />
+	<bean id="com.liferay.portal.service.impl.OrganizationLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.OrganizationLocalServiceStagingAdvice" />
+	<bean id="com.liferay.portal.service.impl.UserGroupGroupRoleLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.UserGroupGroupRoleLocalServiceStagingAdvice" />
+	<bean id="com.liferay.portal.service.impl.UserGroupLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.UserGroupLocalServiceStagingAdvice" />
+	<bean id="com.liferay.portal.service.impl.UserGroupRoleLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.UserGroupRoleLocalServiceStagingAdvice" />
+	<bean id="com.liferay.portal.service.impl.UserLocalServiceStagingAdvice" class="com.liferay.portal.service.impl.UserLocalServiceStagingAdvice" />
 	<bean id="com.liferay.portlet.asset.model.adapter.builder.StagedAssetLinkModelAdapterBuilder" class="com.liferay.portlet.asset.model.adapter.builder.StagedAssetLinkModelAdapterBuilder" />
 	<bean id="com.liferay.portlet.exportimport.lar.PortletDataHandlerStatusMessageSenderUtil" class="com.liferay.portlet.exportimport.lar.PortletDataHandlerStatusMessageSenderUtil">
 		<property name="portletDataHandlerStatusMessageSender">
@@ -26,8 +32,14 @@
 		</property>
 	</bean>
 	<aop:config proxy-target-class="false">
+		<aop:advisor advice-ref="com.liferay.portal.service.impl.GroupLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.GroupLocalService)" />
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.LayoutLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.LayoutLocalService)" />
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.LayoutSetLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.LayoutSetLocalService)" />
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.PortletPreferencesLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.PortletPreferencesLocalService)" />
+		<aop:advisor advice-ref="com.liferay.portal.service.impl.OrganizationLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.OrganizationLocalService)" />
+		<aop:advisor advice-ref="com.liferay.portal.service.impl.UserGroupGroupRoleLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.UserGroupGroupRoleLocalService)" />
+		<aop:advisor advice-ref="com.liferay.portal.service.impl.UserGroupLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.UserGroupLocalService)" />
+		<aop:advisor advice-ref="com.liferay.portal.service.impl.UserGroupRoleLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.UserGroupRoleLocalService)" />
+		<aop:advisor advice-ref="com.liferay.portal.service.impl.UserLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.UserLocalService)" />
 	</aop:config>
 </beans>

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -372,17 +372,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 					groupId = group.getGroupId();
 				}
-
-				// If the group is a staging group, check the live group.
-
-				if (group.isStagingGroup()) {
-					if (primKey.equals(String.valueOf(groupId))) {
-						primKey = String.valueOf(group.getLiveGroupId());
-					}
-
-					groupId = group.getLiveGroupId();
-					group = group.getLiveGroup();
-				}
 			}
 		}
 		catch (Exception e) {

--- a/portal-impl/src/com/liferay/portal/security/permission/PermissionCheckerFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/PermissionCheckerFactoryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.exportimport.staging.permission.StagingPermissionCheckerWrapper;
 
 /**
  * @author Charles May
@@ -33,7 +34,12 @@ public class PermissionCheckerFactoryImpl implements PermissionCheckerFactory {
 			(Class<PermissionChecker>)Class.forName(
 				PropsValues.PERMISSIONS_CHECKER);
 
-		_permissionChecker = clazz.newInstance();
+		PermissionChecker permissionChecker = clazz.newInstance();
+
+		permissionChecker = new StagingPermissionCheckerWrapper(
+			permissionChecker);
+
+		_permissionChecker = permissionChecker;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceStagingAdvice.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("addOrganizationGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addOrganizationGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addRoleGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addRoleGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addUserGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addUserGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addUserGroupGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("addUserGroupGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteOrganizationGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteOrganizationGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteRoleGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteRoleGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroupGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroupGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserGroupPrimaryKeys")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("hasOrganizationGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("hasRoleGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("hasUserGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("hasUserGroupGroup")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("setOrganizationGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("setRoleGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("setUserGroupGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("setUserGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("unsetRoleGroups")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("unsetUserGroups")) {
+			replace(arguments, 1);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/LiveGroupStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LiveGroupStagingAdvice.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.service.GroupLocalService;
+import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
+
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
+
+	public void initGroupServiceBuilderMethods(String relatedEntityName) {
+		if (Validator.isBlank(relatedEntityName)) {
+			return;
+		}
+
+		for (String template : SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES) {
+			String methodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			_serviceBuilderGeneratedMethods.add(methodName);
+		}
+	}
+
+	@Override
+	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+		if (!StagingAdvicesThreadLocal.isEnabled()) {
+			return methodInvocation.proceed();
+		}
+
+		Method method = methodInvocation.getMethod();
+
+		String methodName = method.getName();
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		if (_serviceBuilderGeneratedMethods.contains(methodName)) {
+			replace(arguments, 0);
+		}
+		else {
+			replaceStagingGroupIds(methodName, arguments);
+		}
+
+		return methodInvocation.proceed();
+	}
+
+	public abstract void replaceStagingGroupIds(
+		String methodName, Object[] arguments);
+
+	protected Group replace(Group group) {
+		if ((group != null) && group.isStagingGroup() &&
+			!group.isStagedRemotely()) {
+
+			return group.getLiveGroup();
+		}
+
+		return group;
+	}
+
+	protected long replace(long groupId) {
+		if (groupId == 0) {
+			return groupId;
+		}
+
+		Group group = groupLocalService.fetchGroup(groupId);
+
+		if ((group != null) && group.isStagingGroup() &&
+			!group.isStagedRemotely()) {
+
+			groupId = group.getLiveGroupId();
+		}
+
+		return groupId;
+	}
+
+	protected void replace(Object[] arguments, int index) {
+		if (arguments == null) {
+			return;
+		}
+
+		Object object = arguments[index];
+
+		if (object == null) {
+			return;
+		}
+
+		if (object instanceof Long) {
+			long groupId = (Long)object;
+
+			arguments[index] = replace(groupId);
+
+			return;
+		}
+
+		if (object instanceof Group) {
+			Group group = (Group)object;
+
+			arguments[index] = replace(group);
+
+			return;
+		}
+
+		if (object instanceof long[]) {
+			long[] groupIds = (long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replace(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Long[]) {
+			Long[] groupIds = (Long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replace(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Group[]) {
+			Group[] groups = (Group[])object;
+
+			for (int i = 0; i < groups.length; i++) {
+				groups[i] = replace(groups[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Collection) {
+			Collection collection = (Collection)object;
+
+			if (collection.size() == 0) {
+				return;
+			}
+
+			Iterator it = collection.iterator();
+
+			if (it.hasNext() && (it.next() instanceof Group)) {
+				ArrayList<Group> groups = new ArrayList(collection);
+
+				collection.clear();
+
+				for (Group group : groups) {
+					collection.add(replace(group));
+				}
+
+				return;
+			}
+		}
+
+		throw new IllegalArgumentException("Unknown type " + object.getClass());
+	}
+
+	protected static final String[] SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES =
+		new String[] {
+			"addGroup$1", "addGroup$1s", "clearGroup$1s", "deleteGroup$1",
+			"deleteGroup$1s", "getGroup$1s", "getGroup$1sCount", "hasGroup$1",
+			"hasGroup$1s", "setGroup$1s", "unsetGroup$1s"
+		};
+
+	@BeanReference(type = GroupLocalService.class)
+	protected GroupLocalService groupLocalService;
+
+	private final List<String> _serviceBuilderGeneratedMethods =
+		new ArrayList<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceStagingAdvice.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class OrganizationLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public OrganizationLocalServiceStagingAdvice() {
+		initGroupServiceBuilderMethods("Organization");
+	}
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("getGroupUserOrganizations")) {
+			replace(arguments, 0);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceStagingAdvice.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public RoleLocalServiceStagingAdvice() {
+		initGroupServiceBuilderMethods("Role");
+	}
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("getDefaultGroupRole")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getGroupRelatedRoles")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getTeamRoleMap")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getTeamRoles")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getUserGroupGroupRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserGroupGroupRolesCount")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserGroupRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserRelatedRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserRelatedRoles")) {
+			replace(arguments, 1);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("addUserGroupGroupRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroupGroupRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroupGroupRolesByGroupId")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getUserGroupGroupRoles") &&
+				 (arguments.length == 2) && (arguments[1] instanceof Long)) {
+
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserGroupGroupRolesByGroupAndRole")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("hasUserGroupGroupRole")) {
+			replace(arguments, 1);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceStagingAdvice.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserGroupLocalServiceStagingAdvice() {
+		initGroupServiceBuilderMethods("UserGroup");
+	}
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("getGroupUserUserGroups")) {
+			replace(arguments, 0);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("addUserGroupRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroupRoles")) {
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("deleteUserGroupRolesByGroupId")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getUserGroupRoles") &&
+				 ((arguments.length == 4) ||
+				  ((arguments.length == 2) &&
+				   (arguments[1] instanceof Long)))) {
+
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserGroupRolesByGroup")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("getUserGroupRolesByGroupAndRole")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals(
+					"getUserGroupRolesByUserUserGroupAndGroup")) {
+
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("getUserGroupRolesCount") &&
+				 (arguments.length == 2)) {
+
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("hasUserGroupRole")) {
+			replace(arguments, 1);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6326,14 +6326,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		for (long oldGroupId : oldGroupIds) {
 			if (!ArrayUtil.contains(newGroupIds, oldGroupId)) {
-				unsetGroupUsers(
+				userLocalService.unsetGroupUsers(
 					oldGroupId, new long[] {userId}, serviceContext);
 			}
 		}
 
 		for (long newGroupId : newGroupIds) {
 			if (!ArrayUtil.contains(oldGroupIds, newGroupId)) {
-				addGroupUsers(newGroupId, new long[] {userId});
+				userLocalService.addGroupUsers(newGroupId, new long[] {userId});
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceStagingAdvice.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.impl;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserLocalServiceStagingAdvice() {
+		initGroupServiceBuilderMethods("User");
+	}
+
+	@Override
+	public void replaceStagingGroupIds(String methodName, Object[] arguments) {
+		if (methodName.equals("getGroupUserIds")) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("searchSocial") && (arguments.length == 5) &&
+				 (arguments[1] instanceof Long[])) {
+
+			replace(arguments, 1);
+		}
+		else if (methodName.equals("searchSocial") && (arguments.length == 6)) {
+			replace(arguments, 0);
+		}
+		else if (methodName.equals("unsetGroupTeamsUsers")) {
+			replace(arguments, 0);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -31,9 +31,18 @@ import com.liferay.portal.model.Group;
 import com.liferay.portal.model.GroupConstants;
 import com.liferay.portal.model.LayoutSet;
 import com.liferay.portal.model.Organization;
+import com.liferay.portal.model.Role;
 import com.liferay.portal.model.User;
+import com.liferay.portal.model.UserGroup;
+import com.liferay.portal.model.UserGroupGroupRole;
+import com.liferay.portal.model.UserGroupRole;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.service.RoleLocalServiceUtil;
+import com.liferay.portal.service.UserGroupGroupRoleLocalServiceUtil;
+import com.liferay.portal.service.UserGroupLocalServiceUtil;
+import com.liferay.portal.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.service.impl.GroupLocalServiceImpl;
 import com.liferay.portal.util.PortalInstances;
@@ -282,7 +291,42 @@ public class VerifyGroup extends VerifyProcess {
 
 				GroupLocalServiceUtil.updateGroup(stagingGroup);
 			}
+
+			if (!stagingGroup.isStagedRemotely()) {
+				verifyStagingGroupOrganizationMembership(stagingGroup);
+				verifyStagingGroupRoleMembership(stagingGroup);
+				verifyStagingGroupUserGroupMembership(stagingGroup);
+				verifyStagingGroupUserMembership(stagingGroup);
+				verifyStagingUserGroupRolesAssignments(stagingGroup);
+				verifyStagingUserGroupGroupRolesAssignments(stagingGroup);
+			}
 		}
+	}
+
+	protected void verifyStagingGroupOrganizationMembership(Group stagingGroup)
+		throws Exception {
+
+		List<Organization> staged =
+			OrganizationLocalServiceUtil.getGroupOrganizations(
+				stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<Organization> live =
+			OrganizationLocalServiceUtil.getGroupOrganizations(
+				stagingGroup.getLiveGroupId());
+
+		for (Organization organization : staged) {
+			if (!live.contains(organization)) {
+				OrganizationLocalServiceUtil.addGroupOrganization(
+					stagingGroup.getLiveGroupId(), organization);
+			}
+		}
+
+		OrganizationLocalServiceUtil.clearGroupOrganizations(
+			stagingGroup.getGroupId());
 	}
 
 	protected void verifyStagingTypeSettingsProperties(
@@ -313,6 +357,135 @@ public class VerifyGroup extends VerifyProcess {
 		for (long companyId : companyIds) {
 			GroupLocalServiceUtil.rebuildTree(companyId);
 		}
+	}
+
+	private void verifyStagingGroupRoleMembership(Group stagingGroup) {
+		List<Role> staged = RoleLocalServiceUtil.getGroupRoles(
+			stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<Role> live = RoleLocalServiceUtil.getGroupRoles(
+			stagingGroup.getLiveGroupId());
+
+		for (Role role : staged) {
+			if (!live.contains(role)) {
+				RoleLocalServiceUtil.addGroupRole(
+					stagingGroup.getLiveGroupId(), role);
+			}
+		}
+
+		RoleLocalServiceUtil.clearGroupRoles(stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingGroupUserGroupMembership(Group stagingGroup) {
+		List<UserGroup> staged = UserGroupLocalServiceUtil.getGroupUserGroups(
+			stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<UserGroup> live = UserGroupLocalServiceUtil.getGroupUserGroups(
+			stagingGroup.getLiveGroupId());
+
+		for (UserGroup userGroup : staged) {
+			if (!live.contains(userGroup)) {
+				UserGroupLocalServiceUtil.addGroupUserGroup(
+					stagingGroup.getLiveGroupId(), userGroup);
+			}
+		}
+
+		UserGroupLocalServiceUtil.clearGroupUserGroups(
+			stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingGroupUserMembership(Group stagingGroup) {
+		List<User> staged = UserLocalServiceUtil.getGroupUsers(
+			stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<User> live = UserLocalServiceUtil.getGroupUsers(
+			stagingGroup.getLiveGroupId());
+
+		for (User user : staged) {
+			if (!live.contains(user)) {
+				UserLocalServiceUtil.addGroupUser(
+					stagingGroup.getLiveGroupId(), user);
+			}
+		}
+
+		UserLocalServiceUtil.clearGroupUsers(stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingUserGroupGroupRolesAssignments(
+		Group stagingGroup) {
+
+		DynamicQuery dynamicQuery =
+			UserGroupGroupRoleLocalServiceUtil.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"id.groupId", stagingGroup.getGroupId()));
+
+		List<UserGroupGroupRole> staged =
+			UserGroupGroupRoleLocalServiceUtil.dynamicQuery(dynamicQuery);
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		dynamicQuery = UserGroupGroupRoleLocalServiceUtil.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"id.groupId", stagingGroup.getLiveGroupId()));
+
+		List<UserGroupGroupRole> live =
+			UserGroupGroupRoleLocalServiceUtil.dynamicQuery(dynamicQuery);
+
+		for (UserGroupGroupRole userGroupGroupRole : staged) {
+			userGroupGroupRole.setGroupId(stagingGroup.getLiveGroupId());
+
+			if (!live.contains(userGroupGroupRole)) {
+				UserGroupGroupRoleLocalServiceUtil.updateUserGroupGroupRole(
+					userGroupGroupRole);
+			}
+		}
+
+		UserGroupGroupRoleLocalServiceUtil.deleteUserGroupGroupRolesByGroupId(
+			stagingGroup.getGroupId());
+	}
+
+	private void verifyStagingUserGroupRolesAssignments(Group stagingGroup) {
+		List<UserGroupRole> staged =
+			UserGroupRoleLocalServiceUtil.getUserGroupRolesByGroup(
+				stagingGroup.getGroupId());
+
+		if (staged.isEmpty()) {
+			return;
+		}
+
+		List<UserGroupRole> live =
+			UserGroupRoleLocalServiceUtil.getUserGroupRolesByGroup(
+				stagingGroup.getLiveGroupId());
+
+		for (UserGroupRole userGroupRole : staged) {
+			userGroupRole.setGroupId(stagingGroup.getLiveGroupId());
+
+			if (!live.contains(userGroupRole)) {
+				UserGroupRoleLocalServiceUtil.updateUserGroupRole(
+					userGroupRole);
+			}
+		}
+
+		UserGroupRoleLocalServiceUtil.deleteUserGroupRolesByGroupId(
+			stagingGroup.getGroupId());
 	}
 
 	private static final String[] _LEGACY_STAGED_PORTLET_TYPE_SETTINGS_KEYS = {

--- a/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
@@ -14,9 +14,11 @@
 
 package com.liferay.portlet.exportimport.staging.permission;
 
+import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.security.permission.PermissionCheckerBag;
+import com.liferay.portal.service.GroupLocalServiceUtil;
 
 import java.util.List;
 
@@ -47,8 +49,10 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	public List<Long> getGuestResourceBlockIds(
 		long companyId, long groupId, String name, String actionId) {
 
+		long liveGroupId = getLiveGroupId(groupId);
+
 		return _permissionChecker.getGuestResourceBlockIds(
-			companyId, groupId, name, actionId);
+			companyId, liveGroupId, name, actionId);
 	}
 
 	@Override
@@ -60,8 +64,10 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	public List<Long> getOwnerResourceBlockIds(
 		long companyId, long groupId, String name, String actionId) {
 
+		long liveGroupId = getLiveGroupId(groupId);
+
 		return _permissionChecker.getOwnerResourceBlockIds(
-			companyId, groupId, name, actionId);
+			companyId, liveGroupId, name, actionId);
 	}
 
 	@Override
@@ -74,13 +80,17 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 		long companyId, long groupId, long userId, String name,
 		String actionId) {
 
+		long liveGroupId = getLiveGroupId(groupId);
+
 		return _permissionChecker.getResourceBlockIds(
-			companyId, groupId, userId, name, actionId);
+			companyId, liveGroupId, userId, name, actionId);
 	}
 
 	@Override
 	public long[] getRoleIds(long userId, long groupId) {
-		return _permissionChecker.getRoleIds(userId, groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.getRoleIds(userId, liveGroupId);
 	}
 
 	@Override
@@ -92,7 +102,9 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	public PermissionCheckerBag getUserBag(long userId, long groupId)
 		throws Exception {
 
-		return _permissionChecker.getUserBag(userId, groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.getUserBag(userId, liveGroupId);
 	}
 
 	@Override
@@ -122,16 +134,20 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	public boolean hasPermission(
 		long groupId, String name, long primKey, String actionId) {
 
+		long liveGroupId = getLiveGroupId(groupId);
+
 		return _permissionChecker.hasPermission(
-			groupId, name, primKey, actionId);
+			liveGroupId, name, primKey, actionId);
 	}
 
 	@Override
 	public boolean hasPermission(
 		long groupId, String name, String primKey, String actionId) {
 
+		long liveGroupId = getLiveGroupId(groupId);
+
 		return _permissionChecker.hasPermission(
-			groupId, name, primKey, actionId);
+			liveGroupId, name, primKey, actionId);
 	}
 
 	@Override
@@ -139,8 +155,10 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 		long groupId, String name, String primKey, String actionId,
 		boolean checkAdmin) {
 
+		long liveGroupId = getLiveGroupId(groupId);
+
 		return _permissionChecker.hasUserPermission(
-			groupId, name, primKey, actionId, checkAdmin);
+			liveGroupId, name, primKey, actionId, checkAdmin);
 	}
 
 	@Override
@@ -156,13 +174,17 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	@Deprecated
 	@Override
 	public boolean isCommunityAdmin(long groupId) {
-		return _permissionChecker.isCommunityAdmin(groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.isCommunityAdmin(liveGroupId);
 	}
 
 	@Deprecated
 	@Override
 	public boolean isCommunityOwner(long groupId) {
-		return _permissionChecker.isCommunityOwner(groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.isCommunityOwner(liveGroupId);
 	}
 
 	@Override
@@ -177,22 +199,30 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 
 	@Override
 	public boolean isContentReviewer(long companyId, long groupId) {
-		return _permissionChecker.isContentReviewer(companyId, groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.isContentReviewer(companyId, liveGroupId);
 	}
 
 	@Override
 	public boolean isGroupAdmin(long groupId) {
-		return _permissionChecker.isGroupAdmin(groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.isGroupAdmin(liveGroupId);
 	}
 
 	@Override
 	public boolean isGroupMember(long groupId) {
-		return _permissionChecker.isGroupMember(groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.isGroupMember(liveGroupId);
 	}
 
 	@Override
 	public boolean isGroupOwner(long groupId) {
-		return _permissionChecker.isGroupOwner(groupId);
+		long liveGroupId = getLiveGroupId(groupId);
+
+		return _permissionChecker.isGroupOwner(liveGroupId);
 	}
 
 	@Override
@@ -225,6 +255,18 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	@Override
 	public void setValues(PortletRequest portletRequest) {
 		_permissionChecker.setValues(portletRequest);
+	}
+
+	protected long getLiveGroupId(long groupId) {
+		if (groupId > 0) {
+			Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+			if ((group != null) && group.isStagingGroup()) {
+				return group.getLiveGroupId();
+			}
+		}
+
+		return groupId;
 	}
 
 	private final PermissionChecker _permissionChecker;

--- a/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
@@ -136,6 +136,12 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 
 		long liveGroupId = getLiveGroupId(groupId);
 
+		if (liveGroupId != groupId) {
+			if (primKey == groupId) {
+				primKey = liveGroupId;
+			}
+		}
+
 		return _permissionChecker.hasPermission(
 			liveGroupId, name, primKey, actionId);
 	}
@@ -145,6 +151,12 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 		long groupId, String name, String primKey, String actionId) {
 
 		long liveGroupId = getLiveGroupId(groupId);
+
+		if (liveGroupId != groupId) {
+			if (primKey.equals(String.valueOf(groupId))) {
+				primKey = String.valueOf(liveGroupId);
+			}
+		}
 
 		return _permissionChecker.hasPermission(
 			liveGroupId, name, primKey, actionId);

--- a/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
@@ -17,7 +17,7 @@ package com.liferay.portlet.exportimport.staging.permission;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.PermissionChecker;
-import com.liferay.portal.security.permission.PermissionCheckerBag;
+import com.liferay.portal.security.permission.UserBag;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 
 import java.util.List;
@@ -43,21 +43,6 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	@Override
 	public long getCompanyId() {
 		return _permissionChecker.getCompanyId();
-	}
-
-	@Override
-	public List<Long> getGuestResourceBlockIds(
-		long companyId, long groupId, String name, String actionId) {
-
-		long liveGroupId = getLiveGroupId(groupId);
-
-		return _permissionChecker.getGuestResourceBlockIds(
-			companyId, liveGroupId, name, actionId);
-	}
-
-	@Override
-	public PermissionCheckerBag getGuestUserBag() throws Exception {
-		return _permissionChecker.getGuestUserBag();
 	}
 
 	@Override
@@ -99,12 +84,8 @@ public class StagingPermissionCheckerWrapper implements PermissionChecker {
 	}
 
 	@Override
-	public PermissionCheckerBag getUserBag(long userId, long groupId)
-		throws Exception {
-
-		long liveGroupId = getLiveGroupId(groupId);
-
-		return _permissionChecker.getUserBag(userId, liveGroupId);
+	public UserBag getUserBag() throws Exception {
+		return _permissionChecker.getUserBag();
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/staging/permission/StagingPermissionCheckerWrapper.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.exportimport.staging.permission;
+
+import com.liferay.portal.model.User;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.PermissionCheckerBag;
+
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class StagingPermissionCheckerWrapper implements PermissionChecker {
+
+	public StagingPermissionCheckerWrapper(
+		PermissionChecker permissionChecker) {
+
+		_permissionChecker = permissionChecker;
+	}
+
+	@Override
+	public PermissionChecker clone() {
+		return new StagingPermissionCheckerWrapper(_permissionChecker.clone());
+	}
+
+	@Override
+	public long getCompanyId() {
+		return _permissionChecker.getCompanyId();
+	}
+
+	@Override
+	public List<Long> getGuestResourceBlockIds(
+		long companyId, long groupId, String name, String actionId) {
+
+		return _permissionChecker.getGuestResourceBlockIds(
+			companyId, groupId, name, actionId);
+	}
+
+	@Override
+	public PermissionCheckerBag getGuestUserBag() throws Exception {
+		return _permissionChecker.getGuestUserBag();
+	}
+
+	@Override
+	public List<Long> getOwnerResourceBlockIds(
+		long companyId, long groupId, String name, String actionId) {
+
+		return _permissionChecker.getOwnerResourceBlockIds(
+			companyId, groupId, name, actionId);
+	}
+
+	@Override
+	public long getOwnerRoleId() {
+		return _permissionChecker.getOwnerRoleId();
+	}
+
+	@Override
+	public List<Long> getResourceBlockIds(
+		long companyId, long groupId, long userId, String name,
+		String actionId) {
+
+		return _permissionChecker.getResourceBlockIds(
+			companyId, groupId, userId, name, actionId);
+	}
+
+	@Override
+	public long[] getRoleIds(long userId, long groupId) {
+		return _permissionChecker.getRoleIds(userId, groupId);
+	}
+
+	@Override
+	public User getUser() {
+		return _permissionChecker.getUser();
+	}
+
+	@Override
+	public PermissionCheckerBag getUserBag(long userId, long groupId)
+		throws Exception {
+
+		return _permissionChecker.getUserBag(userId, groupId);
+	}
+
+	@Override
+	public long getUserId() {
+		return _permissionChecker.getUserId();
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, long primKey, long ownerId,
+		String actionId) {
+
+		return _permissionChecker.hasOwnerPermission(
+			companyId, name, primKey, ownerId, actionId);
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, String primKey, long ownerId,
+		String actionId) {
+
+		return _permissionChecker.hasOwnerPermission(
+			companyId, name, primKey, ownerId, actionId);
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, long primKey, String actionId) {
+
+		return _permissionChecker.hasPermission(
+			groupId, name, primKey, actionId);
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, String primKey, String actionId) {
+
+		return _permissionChecker.hasPermission(
+			groupId, name, primKey, actionId);
+	}
+
+	@Override
+	public boolean hasUserPermission(
+		long groupId, String name, String primKey, String actionId,
+		boolean checkAdmin) {
+
+		return _permissionChecker.hasUserPermission(
+			groupId, name, primKey, actionId, checkAdmin);
+	}
+
+	@Override
+	public void init(User user) {
+		_permissionChecker.init(user);
+	}
+
+	@Override
+	public boolean isCheckGuest() {
+		return _permissionChecker.isCheckGuest();
+	}
+
+	@Deprecated
+	@Override
+	public boolean isCommunityAdmin(long groupId) {
+		return _permissionChecker.isCommunityAdmin(groupId);
+	}
+
+	@Deprecated
+	@Override
+	public boolean isCommunityOwner(long groupId) {
+		return _permissionChecker.isCommunityOwner(groupId);
+	}
+
+	@Override
+	public boolean isCompanyAdmin() {
+		return _permissionChecker.isCompanyAdmin();
+	}
+
+	@Override
+	public boolean isCompanyAdmin(long companyId) {
+		return _permissionChecker.isCompanyAdmin(companyId);
+	}
+
+	@Override
+	public boolean isContentReviewer(long companyId, long groupId) {
+		return _permissionChecker.isContentReviewer(companyId, groupId);
+	}
+
+	@Override
+	public boolean isGroupAdmin(long groupId) {
+		return _permissionChecker.isGroupAdmin(groupId);
+	}
+
+	@Override
+	public boolean isGroupMember(long groupId) {
+		return _permissionChecker.isGroupMember(groupId);
+	}
+
+	@Override
+	public boolean isGroupOwner(long groupId) {
+		return _permissionChecker.isGroupOwner(groupId);
+	}
+
+	@Override
+	public boolean isOmniadmin() {
+		return _permissionChecker.isOmniadmin();
+	}
+
+	@Override
+	public boolean isOrganizationAdmin(long organizationId) {
+		return _permissionChecker.isOrganizationAdmin(organizationId);
+	}
+
+	@Override
+	public boolean isOrganizationOwner(long organizationId) {
+		return _permissionChecker.isOrganizationOwner(organizationId);
+	}
+
+	@Override
+	public boolean isSignedIn() {
+		return _permissionChecker.isSignedIn();
+	}
+
+	@Deprecated
+	@Override
+	public void resetValues() {
+		_permissionChecker.resetValues();
+	}
+
+	@Deprecated
+	@Override
+	public void setValues(PortletRequest portletRequest) {
+		_permissionChecker.setValues(portletRequest);
+	}
+
+	private final PermissionChecker _permissionChecker;
+
+}


### PR DESCRIPTION
Hi Ray,

I tried to fix the staging permissions checking in portal framework:
1, checking permissions always on live groupId ... wrapper around PermissionChecker
... to remove staging logic from AdvancedPermissionChecker into own class
... to support user-defined permission checkers so that they will work with staging transparently
2, site-related membership is done on live groupId (user->site, userGroup->site, Org->Site)
... Advices around GroupLS and related LocalServices that are in 1:N relation
... Advices for M:N relations where group is present (User-Group-Role + UserGroup-Group-Role)

I tried to fix the teams but they are fundamentally broken: https://issues.liferay.com/browse/LPS-59563

So teams are in unstable state right now when staging is enabled.

/cc @matethurzo

EDIT: in case we decide to fix LPS-59563 as proposed in the ticket, I have prepared (untested) solution to check staging team permissions in staging and live team permissions in live (https://github.com/topolik/liferay-portal/commits/LPS-57826-III)