### PR TITLE
LPS-60183 layout.friendly.url.keywords contains keywords that should not be reserved and does not contain various servlet paths

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4720,28 +4720,24 @@
         delegate,\
         display_chart*,\
         dtd,\
-        elqNow,\
         facebook,\
         google_gadget,\
         group,\
         html,\
         image,\
         language,\
-        lucene,\
         netvibes,\
         o,\
         osgi,\
-        page,\
         pbhs,\
         poller,\
-        private,\
-        public,\
         rest,\
         robots.txt,\
         sharepoint*,\
         sitemap.xml,\
         software_catalog*,\
-        tunnel-web,\
+        sprite,\
+        user,\
         wap,\
         web,\
         webdav*,\


### PR DESCRIPTION
Hey Ray,

There are some friendly URL keywords that are being blacklisted but they are legacy URLs. Also there are some servlet mappings that are not being excluded which may cause some issues. The only one left out is "/documents" since there is special logic with VirtualHostFilter to handle that case. @holatuwol was looking this over we me and it seems that the property "layout.friendly.url.keywords" is really there to make sure VirtualHostFilter doesn't mess anything up but we couldn't think of a way to refactor it to not need to check against these servlet mappings. Please let me know if you think these changes will break existing behavior or if there is some way to make VirtualHostFilter more intelligent to dispatch to the appropriate servlet.

Thanks!