### PR TITLE
Providing the right versions for the exported packages

### DIFF
--- a/modules/portal/portal-cxf-jaxrs-common/bnd.bnd
+++ b/modules/portal/portal-cxf-jaxrs-common/bnd.bnd
@@ -11,8 +11,8 @@ Bundle-Name: Liferay Portal CXF JAX-RS Common
 Bundle-SymbolicName: com.liferay.portal.cxf.jaxrs.common
 Bundle-Version: 1.0.0
 Export-Package:\
-	javax.json.*,\
-	javax.ws.rs.*,\
+	javax.json.*;version="1.0",\
+	javax.ws.rs.*;version="2.0.1",\
 	org.apache.cxf.*;version="3.0.3"
 Import-Package:\
 	!com.sun.*,\

--- a/modules/portal/portal-cxf-jaxrs-common/bnd.bnd
+++ b/modules/portal/portal-cxf-jaxrs-common/bnd.bnd
@@ -42,3 +42,6 @@ Include-Resource:\
 	lib/=lib/javax.json-api.jar,\
 	lib/=lib/javax.ws.rs-api.jar,\
 	lib/=lib/jettison.jar
+Provide-Capability:\
+	osgi.contract; osgi.contract=JavaJAXRS; version:Version=2; uses:="avax.ws.rs, javax.ws.rs.core, javax.ws.rs.ext, javax.ws.rs.client, javax.ws.rs.container",\
+	osgi.contract; osgi.contract=JavaJSONP; version:Version=1; uses:="javax.json, javax.json.stream, javax.json.spi"


### PR DESCRIPTION
I hope we can have this manual fix until we figure out how to automate the process if exporting the right package version of the embedded 3rd party packages?