### PR TITLE
LPS-61843 PortalImpl.getHttpServletRequest() should be bundle aware

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/portlet/action/LoginMVCActionCommand.java
@@ -172,8 +172,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			ActionResponse actionResponse)
 		throws Exception {
 
-		HttpServletRequest request = PortalUtil.getHttpServletRequest(
-			actionRequest);
+		HttpServletRequest request = PortalUtil.getOriginalServletRequest(
+			PortalUtil.getHttpServletRequest(actionRequest));
 		HttpServletResponse response = PortalUtil.getHttpServletResponse(
 			actionResponse);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
 import com.liferay.portal.kernel.servlet.PortalMessages;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.servlet.PortalWebResourcesUtil;
+import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
@@ -2554,6 +2555,14 @@ public class PortalImpl implements Portal {
 	public HttpServletRequest getHttpServletRequest(
 		PortletRequest portletRequest) {
 
+		HttpServletRequest httpServletRequest = 
+			(HttpServletRequest)portletRequest.getAttribute(
+				PortletServlet.PORTLET_SERVLET_REQUEST);
+		
+		if (httpServletRequest != null) {
+			return httpServletRequest;
+		}
+		
 		if (portletRequest instanceof LiferayPortletRequest) {
 			LiferayPortletRequest liferayPortletRequest =
 				(LiferayPortletRequest)portletRequest;


### PR DESCRIPTION
Hi Ray. I believe there is a issue with how PortalImpl.getHttpServletRequest() is implemented which means by using PortalUtil.getHttpServletRequest(PortalRequest) a portlet has full access to attributes (inc. session) set into the HttpServletRequest by other modules. But I may be misunderstanding something here and impact can be far reaching, so can you please sanity check? If you agree with this change in principle, I will spend time resolving the test failures & push additional commits. Thanks!

p.s. I've done smoke testing of portal functionality and found no regressions beyond inability to log in, which is also fixed in this PR.