### PR TITLE
LPS-63181 InlineSQLHelperImpl cannot rely on SCOPE_INDIVIDUAL resource permission

### DIFF
--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarResourceServiceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarResourceServiceTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.service.test.ServiceTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
@@ -54,6 +55,8 @@ public class CalendarResourceServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_user = UserTestUtil.addUser();
+
+		ServiceTestUtil.setUser(_user);
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/InlineSQLHelperImpl.java
@@ -75,7 +75,9 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			PermissionThreadLocal.getPermissionChecker();
 
 		if (permissionChecker == null) {
-			return false;
+			throw new IllegalStateException(
+				"Unable to use InlineSQLHelper without PermissionChecker " +
+					"being properly initialized");
 		}
 
 		if (groupId > 0) {

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/PersistenceTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/PersistenceTestCallback.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ModelListenerRegistrationUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.callback.BaseTestCallback;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.service.test.ServiceTestUtil;
 import com.liferay.portal.tools.DBUpgrader;
 
 import java.util.List;
@@ -48,7 +50,9 @@ public class PersistenceTestCallback extends BaseTestCallback<Object, Object> {
 	}
 
 	@Override
-	public Object beforeMethod(Description description, Object target) {
+	public Object beforeMethod(Description description, Object target)
+		throws Exception {
+
 		initialize();
 
 		Object instance = ReflectionTestUtil.getFieldValue(
@@ -62,6 +66,8 @@ public class PersistenceTestCallback extends BaseTestCallback<Object, Object> {
 			new ConcurrentHashMap<Class<?>, List<ModelListener<?>>>());
 
 		CacheRegistryUtil.setActive(false);
+
+		ServiceTestUtil.setUser(TestPropsValues.getUser());
 
 		return modelListeners;
 	}


### PR DESCRIPTION
Hi Ray,

https://issues.liferay.com/browse/LPS-63181

InlineSQLHelperImpl used following permission check to skip updating the SQL.

```
if (permissionChecker.hasPermission(
	checkGroupId, className, 0, ActionKeys.VIEW)) {

	return sql;
}
```

But after the indiviual resource fix this won't work, there is no entity with primKey==0.

To keep the logic I'm checking resource permissions on higher levels manually.

Thanks.