### PR TITLE
LPS-63022 Create permission resources for all entities that are used in the permission framework

### DIFF
--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/service.xml
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/service.xml
@@ -131,6 +131,7 @@
 		<reference package-path="com.liferay.mobile.device.rules" entity="MDRRule" />
 		<reference package-path="com.liferay.mobile.device.rules" entity="MDRRuleGroupInstance" />
 		<reference package-path="com.liferay.portal" entity="Group" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="SystemEvent" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>
@@ -190,6 +191,7 @@
 		<reference package-path="com.liferay.portal" entity="ClassName" />
 		<reference package-path="com.liferay.portal" entity="Layout" />
 		<reference package-path="com.liferay.portal" entity="LayoutSet" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="SystemEvent" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
@@ -729,6 +729,25 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -883,6 +902,8 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.LayoutSetLocalService layoutSetLocalService;
 	@ServiceReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupInstanceServiceBaseImpl.java
@@ -439,6 +439,25 @@ public abstract class MDRRuleGroupInstanceServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -620,6 +639,8 @@ public abstract class MDRRuleGroupInstanceServiceBaseImpl
 	protected com.liferay.portal.kernel.service.LayoutSetService layoutSetService;
 	@ServiceReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
@@ -585,6 +585,25 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -765,6 +784,8 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.GroupLocalService groupLocalService;
 	@ServiceReference(type = GroupPersistence.class)
 	protected GroupPersistence groupPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupServiceBaseImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/base/MDRRuleGroupServiceBaseImpl.java
@@ -263,6 +263,25 @@ public abstract class MDRRuleGroupServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the system event local service.
 	 *
 	 * @return the system event local service
@@ -483,6 +502,8 @@ public abstract class MDRRuleGroupServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.GroupService groupService;
 	@ServiceReference(type = GroupPersistence.class)
 	protected GroupPersistence groupPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SystemEventLocalService.class)
 	protected com.liferay.portal.kernel.service.SystemEventLocalService systemEventLocalService;
 	@ServiceReference(type = SystemEventPersistence.class)

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
@@ -66,6 +66,11 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 		ruleGroupInstance.setRuleGroupId(ruleGroupId);
 		ruleGroupInstance.setPriority(priority);
 
+		// Resources
+
+		resourceLocalService.addModelResources(
+			ruleGroupInstance, serviceContext);
+
 		return updateMDRRuleGroupInstance(ruleGroupInstance);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -67,6 +67,10 @@ public class MDRRuleGroupLocalServiceImpl
 		ruleGroup.setNameMap(nameMap);
 		ruleGroup.setDescriptionMap(descriptionMap);
 
+		// Resources
+
+		resourceLocalService.addModelResources(ruleGroup, serviceContext);
+
 		return updateMDRRuleGroup(ruleGroup);
 	}
 

--- a/modules/apps/shopping/shopping-service/service.xml
+++ b/modules/apps/shopping/shopping-service/service.xml
@@ -395,6 +395,7 @@
 
 		<reference package-path="com.liferay.mail" entity="Mail" />
 		<reference package-path="com.liferay.portal" entity="Company" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="Subscription" />
 		<reference package-path="com.liferay.portal" entity="User" />
 		<reference package-path="com.liferay.shopping" entity="ShoppingItem" />

--- a/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderLocalServiceBaseImpl.java
+++ b/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderLocalServiceBaseImpl.java
@@ -432,6 +432,25 @@ public abstract class ShoppingOrderLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the subscription local service.
 	 *
 	 * @return the subscription local service
@@ -702,6 +721,8 @@ public abstract class ShoppingOrderLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.CompanyLocalService companyLocalService;
 	@ServiceReference(type = CompanyPersistence.class)
 	protected CompanyPersistence companyPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SubscriptionLocalService.class)
 	protected com.liferay.portal.kernel.service.SubscriptionLocalService subscriptionLocalService;
 	@ServiceReference(type = SubscriptionPersistence.class)

--- a/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderServiceBaseImpl.java
+++ b/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/base/ShoppingOrderServiceBaseImpl.java
@@ -229,6 +229,25 @@ public abstract class ShoppingOrderServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the subscription local service.
 	 *
 	 * @return the subscription local service
@@ -539,6 +558,8 @@ public abstract class ShoppingOrderServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.CompanyService companyService;
 	@ServiceReference(type = CompanyPersistence.class)
 	protected CompanyPersistence companyPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@ServiceReference(type = com.liferay.portal.kernel.service.SubscriptionLocalService.class)
 	protected com.liferay.portal.kernel.service.SubscriptionLocalService subscriptionLocalService;
 	@ServiceReference(type = SubscriptionPersistence.class)

--- a/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/impl/ShoppingOrderLocalServiceImpl.java
+++ b/modules/apps/shopping/shopping-service/src/main/java/com/liferay/shopping/service/impl/ShoppingOrderLocalServiceImpl.java
@@ -147,6 +147,13 @@ public class ShoppingOrderLocalServiceImpl
 				order.getUserName());
 		}
 
+		// Resources
+
+		resourceLocalService.addResources(
+			order.getCompanyId(), order.getGroupId(), order.getUserId(),
+			ShoppingOrder.class.getName(), order.getOrderId(), false, true,
+			false);
+
 		return order;
 	}
 

--- a/modules/apps/shopping/shopping-service/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/shopping/shopping-service/src/main/resources/META-INF/resource-actions/default.xml
@@ -102,12 +102,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>VIEW</action-key>
 			</guest-unsupported>

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -719,6 +719,7 @@
 		<reference package-path="com.liferay.portal" entity="LayoutRevision" />
 		<reference package-path="com.liferay.portal" entity="LayoutSetBranch" />
 		<reference package-path="com.liferay.portal" entity="RecentLayoutBranch" />
+		<reference package-path="com.liferay.portal" entity="Resource" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>
 	<entity name="LayoutFriendlyURL" uuid="true" local-service="true" remote-service="false">

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutBranchLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutBranchLocalServiceBaseImpl.java
@@ -487,6 +487,25 @@ public abstract class LayoutBranchLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the user local service.
 	 *
 	 * @return the user local service
@@ -611,6 +630,8 @@ public abstract class LayoutBranchLocalServiceBaseImpl
 	protected com.liferay.portal.kernel.service.RecentLayoutBranchLocalService recentLayoutBranchLocalService;
 	@BeanReference(type = RecentLayoutBranchPersistence.class)
 	protected RecentLayoutBranchPersistence recentLayoutBranchPersistence;
+	@BeanReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.kernel.service.UserLocalService.class)
 	protected com.liferay.portal.kernel.service.UserLocalService userLocalService;
 	@BeanReference(type = UserPersistence.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutBranchServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutBranchServiceBaseImpl.java
@@ -282,6 +282,25 @@ public abstract class LayoutBranchServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the resource local service.
+	 *
+	 * @return the resource local service
+	 */
+	public com.liferay.portal.kernel.service.ResourceLocalService getResourceLocalService() {
+		return resourceLocalService;
+	}
+
+	/**
+	 * Sets the resource local service.
+	 *
+	 * @param resourceLocalService the resource local service
+	 */
+	public void setResourceLocalService(
+		com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService) {
+		this.resourceLocalService = resourceLocalService;
+	}
+
+	/**
 	 * Returns the user local service.
 	 *
 	 * @return the user local service
@@ -427,6 +446,8 @@ public abstract class LayoutBranchServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.RecentLayoutBranchLocalService recentLayoutBranchLocalService;
 	@BeanReference(type = RecentLayoutBranchPersistence.class)
 	protected RecentLayoutBranchPersistence recentLayoutBranchPersistence;
+	@BeanReference(type = com.liferay.portal.kernel.service.ResourceLocalService.class)
+	protected com.liferay.portal.kernel.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.kernel.service.UserLocalService.class)
 	protected com.liferay.portal.kernel.service.UserLocalService userLocalService;
 	@BeanReference(type = com.liferay.portal.kernel.service.UserService.class)

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -67,6 +67,13 @@ public class LayoutBranchLocalServiceImpl
 
 		layoutBranchPersistence.update(layoutBranch);
 
+		// Resources
+
+		resourceLocalService.addResources(
+			layoutBranch.getCompanyId(), layoutBranch.getGroupId(),
+			layoutBranch.getUserId(), LayoutBranch.class.getName(),
+			layoutBranch.getLayoutBranchId(), false, true, false);
+
 		StagingUtil.setRecentLayoutBranchId(
 			user, layoutBranch.getLayoutSetBranchId(), layoutBranch.getPlid(),
 			layoutBranch.getLayoutBranchId());

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
@@ -78,11 +78,9 @@ public class LayoutPrototypeLocalServiceImpl
 
 		// Resources
 
-		if (userId > 0) {
-			resourceLocalService.addResources(
-				companyId, 0, userId, LayoutPrototype.class.getName(),
-				layoutPrototype.getLayoutPrototypeId(), false, false, false);
-		}
+		resourceLocalService.addResources(
+			companyId, 0, userId, LayoutPrototype.class.getName(),
+			layoutPrototype.getLayoutPrototypeId(), false, true, false);
 
 		// Group
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -84,12 +84,9 @@ public class LayoutSetPrototypeLocalServiceImpl
 
 		// Resources
 
-		if (userId > 0) {
-			resourceLocalService.addResources(
-				companyId, 0, userId, LayoutSetPrototype.class.getName(),
-				layoutSetPrototype.getLayoutSetPrototypeId(), false, false,
-				false);
-		}
+		resourceLocalService.addResources(
+			companyId, 0, userId, LayoutSetPrototype.class.getName(),
+			layoutSetPrototype.getLayoutSetPrototypeId(), false, true, false);
 
 		// Group
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -105,11 +105,15 @@ public class PasswordPolicyLocalServiceImpl
 
 		// Resources
 
-		if (!user.isDefaultUser()) {
-			resourceLocalService.addResources(
-				user.getCompanyId(), 0, userId, PasswordPolicy.class.getName(),
-				passwordPolicy.getPasswordPolicyId(), false, false, false);
+		long ownerId = userId;
+
+		if (user.isDefaultUser()) {
+			ownerId = 0;
 		}
+
+		resourceLocalService.addResources(
+			user.getCompanyId(), 0, ownerId, PasswordPolicy.class.getName(),
+			passwordPolicy.getPasswordPolicyId(), false, false, false);
 
 		return passwordPolicy;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.spring.aop.Skip;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -151,6 +152,16 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		rolePersistence.update(role);
 
 		// Resources
+
+		long ownerId = userId;
+
+		if (user.isDefaultUser()) {
+			ownerId = 0;
+		}
+
+		resourceLocalService.addResources(
+			user.getCompanyId(), 0, ownerId, Role.class.getName(),
+			role.getRoleId(), false, false, false);
 
 		if (!user.isDefaultUser()) {
 			resourceLocalService.addResources(
@@ -290,14 +301,22 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 			checkSystemRole(companyId, name, descriptionMap, type);
 		}
 
+		String[] allSystemRoles = ArrayUtil.append(
+			systemRoles, systemOrganizationRoles, systemSiteRoles);
+
+		for (String roleName : allSystemRoles) {
+			Role role = getRole(companyId, roleName);
+
+			resourceLocalService.addResources(
+				companyId, 0, 0, Role.class.getName(), role.getRoleId(), false,
+				false, false);
+		}
+
 		// All users should be able to view all system roles
 
 		Role userRole = getRole(companyId, RoleConstants.USER);
 
-		String[] userViewableRoles = ArrayUtil.append(
-			systemRoles, systemOrganizationRoles, systemSiteRoles);
-
-		for (String roleName : userViewableRoles) {
+		for (String roleName : allSystemRoles) {
 			Role role = getRole(companyId, roleName);
 
 			resourcePermissionLocalService.setResourcePermissions(
@@ -1311,9 +1330,16 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		catch (NoSuchRoleException nsre) {
 			User user = userLocalService.getDefaultUser(companyId);
 
-			role = roleLocalService.addRole(
-				user.getUserId(), null, 0, name, null, descriptionMap, type,
-				null, null);
+			PermissionThreadLocal.setAddResource(false);
+
+			try {
+				role = roleLocalService.addRole(
+					user.getUserId(), null, 0, name, null, descriptionMap, type,
+					null, null);
+			}
+			finally {
+				PermissionThreadLocal.setAddResource(true);
+			}
 
 			if (name.equals(RoleConstants.USER)) {
 				initPersonalControlPanelPortletsPermissions(role);

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -94,6 +94,10 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 
 		assetTagPersistence.update(tag);
 
+		// Resources
+
+		resourceLocalService.addModelResources(tag, serviceContext);
+
 		return tag;
 	}
 


### PR DESCRIPTION
Hi Ray,

https://issues.liferay.com/browse/LPS-63022

I went through all resource models and made sure we create permission resources for them.

We also need to create the records for system roles and default PasswordPolicy, because those are also part of permission system checking (and currently silently ignored).