### PR TITLE
LPS-63021 Create default SCOPE_INDIVIDUAL ResourcePermission records for each <model-resource> so that portal can check general ENTITY.ACTION (User.VIEW) without having real entity (User)

### DIFF
--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -95,19 +95,19 @@ PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPre
 
 boolean filterManageableOrganizations = true;
 
-if (permissionChecker.hasPermission(scopeGroupId, User.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (permissionChecker.hasPermission(scopeGroupId, User.class.getName(), User.class.getName(), ActionKeys.VIEW)) {
 	filterManageableOrganizations = false;
 }
 
 String portletId = PortletProviderUtil.getPortletId(PortalMyAccountApplicationType.MyAccount.CLASS_NAME, PortletProvider.Action.VIEW);
 
-if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, Organization.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, Organization.class.getName(), Organization.class.getName(), ActionKeys.VIEW)) {
 	filterManageableOrganizations = false;
 }
 
 boolean filterManageableUserGroups = true;
 
-if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, UserGroup.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (portletName.equals(portletId) || permissionChecker.hasPermission(scopeGroupId, UserGroup.class.getName(), UserGroup.class.getName(), ActionKeys.VIEW)) {
 	filterManageableUserGroups = false;
 }
 %>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_assignments.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_assignments.jsp
@@ -80,7 +80,7 @@ renderResponse.setTitle(organization.getName());
 		if (tabs2.equals("current")) {
 			userParams.put("usersOrgs", Long.valueOf(organization.getOrganizationId()));
 		}
-		else if (PropsValues.ORGANIZATIONS_ASSIGNMENT_STRICT && !permissionChecker.isCompanyAdmin() && !permissionChecker.hasPermission(scopeGroupId, User.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+		else if (PropsValues.ORGANIZATIONS_ASSIGNMENT_STRICT && !permissionChecker.isCompanyAdmin() && !permissionChecker.hasPermission(scopeGroupId, User.class.getName(), User.class.getName(), ActionKeys.VIEW)) {
 			userParams.put("usersOrgsTree", user.getOrganizations(true));
 		}
 		%>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -201,7 +201,7 @@ boolean filterManageableGroups = true;
 
 boolean filterManageableOrganizations = true;
 
-if (permissionChecker.hasPermission(0, Organization.class.getName(), company.getCompanyId(), ActionKeys.VIEW)) {
+if (permissionChecker.hasPermission(0, Organization.class.getName(), Organization.class.getName(), ActionKeys.VIEW)) {
 	filterManageableOrganizations = false;
 }
 

--- a/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
@@ -211,7 +211,7 @@ public class GroupPermissionImpl
 		PermissionChecker permissionChecker, String actionId) {
 
 		return permissionChecker.hasPermission(
-			0, Group.class.getName(), 0, actionId);
+			0, Group.class.getName(), Group.class.getName(), actionId);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/social/service/permission/SocialActivityPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/permission/SocialActivityPermissionImpl.java
@@ -49,7 +49,7 @@ public class SocialActivityPermissionImpl implements SocialActivityPermission {
 		}
 
 		if (permissionChecker.hasPermission(
-				groupId, getPortletId(), 0, actionId)) {
+				groupId, getPortletId(), getPortletId(), actionId)) {
 
 			return true;
 		}


### PR DESCRIPTION
Hi Ray,

https://issues.liferay.com/browse/LPS-63021

I didn't know it but on several places in portal we check model permissions without having individual primary key.

For example we have `permissionChecker.hasPermission(0, User.class.getName(), companyId, Action.VIEW)` to know if user has assigned a company scoped permission to view all users. Which now obviously doesn't work, because there is no SCOPE_INDIVIDUAL record with primary key == companyId.

So I solved it the same way you did for portlets - created a default SCOPE_INDIVIDUAL record for the models. This fixes also https://issues.liferay.com/browse/LPS-51807.

Uhm, now I see the commit message related to `AdvancedPermissionChecker.fixLegacyPrimaryKey()` may be confusing, because I first fixed LPS-63020 (will be next PR). Let me please know if I should rephrase it. 

Thanks!