### PR TITLE
LPS-63020 Permission framework must fail any check for missing SCOPE_INDIVIDUAL resource permission

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.Team;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -49,7 +48,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.TeamLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutSetPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
@@ -883,14 +881,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 			companyId = group.getCompanyId();
-		}
-		else if (name.equals(User.class.getName())) {
-			User user = UserLocalServiceUtil.fetchUser(
-				GetterUtil.getLong(primKey));
-
-			if (user != null) {
-				companyId = user.getCompanyId();
-			}
 		}
 
 		try {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -867,6 +867,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		stopWatch.start();
 
+		if (isOmniadmin()) {
+			return true;
+		}
+
+		if (name.equals(Organization.class.getName())) {
+			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
+				return true;
+			}
+		}
+
 		long companyId = user.getCompanyId();
 
 		if (groupId > 0) {
@@ -880,29 +890,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			if (user != null) {
 				companyId = user.getCompanyId();
-			}
-		}
-
-		boolean hasLayoutManagerPermission = true;
-
-		// Check if the layout manager has permission to do this action for the
-		// current portlet
-
-		if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
-			primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
-
-			hasLayoutManagerPermission =
-				PortletPermissionUtil.hasLayoutManagerPermission(
-					name, actionId);
-		}
-
-		if (isOmniadmin()) {
-			return true;
-		}
-
-		if (name.equals(Organization.class.getName())) {
-			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
-				return true;
 			}
 		}
 
@@ -930,8 +917,23 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return true;
 		}
 
-		if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
-			return true;
+		if (isGroupAdminImpl(groupId)) {
+			boolean hasLayoutManagerPermission = true;
+
+			// Check if the layout manager has permission to do this action for
+			// the current portlet
+
+			if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
+				primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+
+				hasLayoutManagerPermission =
+					PortletPermissionUtil.hasLayoutManagerPermission(
+						name, actionId);
+			}
+
+			if (hasLayoutManagerPermission) {
+				return true;
+			}
 		}
 
 		return false;

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.security.permission;
 
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -816,6 +817,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				defaultUserId, groupId, resources, actionId,
 				getGuestUserRoleIds());
 		}
+		catch (MissingIndividualScopeResourcePermissionException misrpe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Somebody is trying to circumvent permission framework " +
+						"or there is a bug in permission framework caller",
+					misrpe);
+			}
+
+			return false;
+		}
 		catch (Exception e) {
 			_log.error(e, e);
 
@@ -885,7 +896,7 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					name, actionId);
 		}
 
-		if (isCompanyAdminImpl(companyId)) {
+		if (isOmniadmin()) {
 			return true;
 		}
 
@@ -894,12 +905,36 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				return true;
 			}
 		}
-		else if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
+
+		try {
+			boolean hasPermission = doCheckPermission(
+				companyId, groupId, name, primKey, roleIds, actionId,
+				stopWatch);
+
+			if (hasPermission) {
+				return true;
+			}
+		}
+		catch (MissingIndividualScopeResourcePermissionException misrpe) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Somebody is trying to circumvent permission framework " +
+						"or there is a bug in permission framework caller",
+					misrpe);
+			}
+
+			return false;
+		}
+
+		if (isCompanyAdminImpl(companyId)) {
 			return true;
 		}
 
-		return doCheckPermission(
-			companyId, groupId, name, primKey, roleIds, actionId, stopWatch);
+		if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
+			return true;
+		}
+
+		return false;
 	}
 
 	protected boolean isCompanyAdminImpl(long companyId) throws Exception {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermiss
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.GroupedModel;
@@ -692,6 +693,28 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 	}
 
+	protected String fixLegacyPrimaryKey(
+		long companyId, String name, String primKey) {
+
+		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+			(primKey.equals(String.valueOf(companyId)) &&
+			 !name.equals(Company.class.getName()))) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Legacy primary key " + primKey + " was used for " +
+						"permission checking of " + name + " in company " +
+						companyId + ". Please use " + name + " as the " +
+						"primary key.",
+					new Exception());
+			}
+
+			return name;
+		}
+
+		return primKey;
+	}
+
 	/**
 	 * Returns representations of the resource at each scope level.
 	 *
@@ -798,8 +821,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		long companyId = user.getCompanyId();
 
-		List<Resource> resources = getResources(
-			companyId, groupId, name, primKey, actionId);
+		if (groupId > 0) {
+			Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+			companyId = group.getCompanyId();
+		}
 
 		try {
 			if (ResourceBlockLocalServiceUtil.isSupported(name)) {
@@ -810,6 +836,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					name, GetterUtil.getLong(primKey), actionId,
 					resourceBlockIdsBag);
 			}
+
+			primKey = fixLegacyPrimaryKey(companyId, name, primKey);
+
+			List<Resource> resources = getResources(
+				companyId, groupId, name, primKey, actionId);
 
 			return ResourceLocalServiceUtil.hasUserPermissions(
 				defaultUserId, groupId, resources, actionId,
@@ -882,6 +913,8 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			companyId = group.getCompanyId();
 		}
+
+		primKey = fixLegacyPrimaryKey(companyId, name, primKey);
 
 		try {
 			boolean hasPermission = doCheckPermission(

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -3357,6 +3357,7 @@
 		<exception>LayoutSetVirtualHost</exception>
 		<exception>LayoutType</exception>
 		<exception>MembershipRequestComments</exception>
+		<exception>MissingIndividualScopeResourcePermission</exception>
 		<exception>OldServiceComponent</exception>
 		<exception>OrganizationId</exception>
 		<exception>OrganizationName</exception>

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.Type;
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -690,7 +691,10 @@ public class ResourcePermissionLocalServiceImpl
 				individualResource.getScope(),
 				individualResource.getPrimKey()) < 1) {
 
-			return false;
+			throw new MissingIndividualScopeResourcePermissionException(
+				"There is no " + individualResource.getName() +
+					" with primary key " + individualResource.getPrimKey() +
+						" and companyId " + individualResource.getCompanyId());
 		}
 
 		// Iterate the list of resources in reverse order to test permissions

--- a/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
+++ b/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.exception;
+
+import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+@ProviderType
+public class MissingIndividualScopeResourcePermissionException
+	extends PortalException {
+
+	public MissingIndividualScopeResourcePermissionException() {
+	}
+
+	public MissingIndividualScopeResourcePermissionException(String msg) {
+		super(msg);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(
+		String msg, Throwable cause) {
+
+		super(msg, cause);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(Throwable cause) {
+		super(cause);
+	}
+
+}


### PR DESCRIPTION
Hi Ray,

https://issues.liferay.com/browse/LPS-63020

We still leak some cross-company data (https://issues.liferay.com/browse/LPS-59647). The problem is here: https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java#L888

We don't honor missing SCOPE_INDIVIDUAL record, if the current user is companyAdmin then we simply skip the check.

My solution is to throw `MissingIndividualScopeResourcePermissionException` in ResourcePermissionLSI so that AdvancedPermissionChecker can distinguish between:
1, User doesn't have assigned permissions (companyId is correct)... we can check global admins permission
2, There is no SCOPE_INDIVIDUAL record ... don't continue!!!

----
This change also uncovered many hidden problems that I'm fixing in all the other pulls. Before this pull request, for company admin all test scenarios worked. isCompanyAdmin() returned `true` before ResourcePermissionLSI was able to return `false` for missing individual records. 

So we had no test failures and QA didn't report anything.

----
Github is displaying the commits in a wrong order - I forgot to change date/time when I prepared the pull, I'm sorry.

Thanks!