### PR TITLE
LPS-63695 SCOPE_GROUP root model-resource is missing by default, custom plugins will fail permission checking

### DIFF
--- a/modules/apps/business-productivity/calendar/calendar-service/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/business-productivity/calendar/calendar-service/src/main/resources/META-INF/resource-actions/default.xml
@@ -7,6 +7,7 @@
 		<portlet-ref>
 			<portlet-name>com_liferay_calendar_web_portlet_CalendarPortlet</portlet-name>
 		</portlet-ref>
+		<root>true</root>
 		<permissions>
 			<supports>
 				<action-key>ADD_RESOURCE</action-key>

--- a/modules/apps/collaboration/microblogs/microblogs-web/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/collaboration/microblogs/microblogs-web/src/main/resources/resource-actions/default.xml
@@ -23,6 +23,7 @@
 			<portlet-name>com_liferay_microblogs_web_portlet_MicroblogsPortlet</portlet-name>
 			<portlet-name>com_liferay_microblogs_web_portlet_MicroblogsStatusUpdatePortlet</portlet-name>
 		</portlet-ref>
+		<root>true</root>
 		<permissions>
 			<supports>
 				<action-key>ADD_ENTRY</action-key>

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -715,17 +715,18 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		String newIndividualResourcePrimKey = null;
 
-		if ((groupId > 0) && ResourceActionsUtil.isRootModelResource(name)) {
+		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
 
-			// There are no custom permissions defined for root model-resource,
-			// use defaults
+			// There are no custom permissions defined for portlet, use defaults
 
 			newIndividualResourcePrimKey = name;
 		}
 
-		else if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+		else if ((groupId > 0) &&
+				 ResourceActionsUtil.isRootModelResource(name)) {
 
-			// There are no custom permissions defined for portlet, use defaults
+			// There are no custom permissions defined for root model-resource,
+			// use defaults
 
 			newIndividualResourcePrimKey = name;
 		}

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -762,6 +762,24 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return resources;
 		}
 
+		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+
+			// There are no custom permissions defined for portlet, use defaults
+
+			Resource individualResource = resources.get(0);
+
+			if (individualResource.getScope() !=
+				ResourceConstants.SCOPE_INDIVIDUAL) {
+
+				throw new IllegalArgumentException(
+					"The first resource must be an individual scope");
+			}
+
+			individualResource.setPrimKey(name);
+
+			return resources;
+		}
+
 		return resources;
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -568,6 +568,9 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		List<Resource> resources = getResources(
 			companyId, groupId, name, primKey, actionId);
 
+		resources = fixMissingResources(
+			companyId, groupId, name, primKey, actionId, resources);
+
 		logHasUserPermission(groupId, name, primKey, actionId, stopWatch, 3);
 
 		// Check if user has access to perform the action on the given resource
@@ -727,6 +730,14 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		return primKey;
 	}
 
+	protected List<Resource> fixMissingResources(
+			long companyId, long groupId, String name, String primKey,
+			String actionId, List<Resource> resources)
+		throws Exception {
+
+		return resources;
+	}
+
 	/**
 	 * Returns representations of the resource at each scope level.
 	 *
@@ -853,6 +864,9 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			List<Resource> resources = getResources(
 				companyId, groupId, name, primKey, actionId);
+
+			resources = fixMissingResources(
+				companyId, groupId, name, primKey, actionId, resources);
 
 			return ResourceLocalServiceUtil.hasUserPermissions(
 				defaultUserId, groupId, resources, actionId,

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -735,6 +735,33 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			String actionId, List<Resource> resources)
 		throws Exception {
 
+		int count =
+			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey);
+
+		if (count > 0) {
+			return resources;
+		}
+
+		if ((groupId > 0) && ResourceActionsUtil.isRootModelResource(name)) {
+
+			// There are no custom permissions defined for root model-resource,
+			// use defaults
+
+			Resource individualResource = resources.get(0);
+
+			if (individualResource.getScope() !=
+					ResourceConstants.SCOPE_INDIVIDUAL) {
+
+				throw new IllegalArgumentException(
+					"The first resource must be an individual scope");
+			}
+
+			individualResource.setPrimKey(name);
+
+			return resources;
+		}
+
 		return resources;
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -700,36 +700,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 	}
 
-	protected String fixLegacyPrimaryKey(
-		long companyId, String name, String primKey) {
-
-		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
-			(primKey.equals(String.valueOf(companyId)) &&
-			 !name.equals(Company.class.getName()))) {
-
-			if (_log.isWarnEnabled()) {
-				StringBundler sb = new StringBundler(9);
-
-				sb.append("Using ");
-				sb.append(name);
-				sb.append(" as the primary key instead of the legacy primary ");
-				sb.append("key ");
-				sb.append(primKey);
-				sb.append(" that was used for permission checking of ");
-				sb.append(name);
-				sb.append(" in company ");
-				sb.append(companyId);
-
-				_log.warn(
-					sb.toString(), new IllegalArgumentException(sb.toString()));
-			}
-
-			return name;
-		}
-
-		return primKey;
-	}
-
 	protected List<Resource> fixMissingResources(
 			long companyId, long groupId, String name, String primKey,
 			String actionId, List<Resource> resources)
@@ -765,6 +735,41 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
 
 			// There are no custom permissions defined for portlet, use defaults
+
+			Resource individualResource = resources.get(0);
+
+			if (individualResource.getScope() !=
+				ResourceConstants.SCOPE_INDIVIDUAL) {
+
+				throw new IllegalArgumentException(
+					"The first resource must be an individual scope");
+			}
+
+			individualResource.setPrimKey(name);
+
+			return resources;
+		}
+
+		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+			(primKey.equals(String.valueOf(companyId)) &&
+				!name.equals(Company.class.getName()))) {
+
+			if (_log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(9);
+
+				sb.append("Using ");
+				sb.append(name);
+				sb.append(" as the primary key instead of the legacy primary ");
+				sb.append("key ");
+				sb.append(primKey);
+				sb.append(" that was used for permission checking of ");
+				sb.append(name);
+				sb.append(" in company ");
+				sb.append(companyId);
+
+				_log.warn(
+					sb.toString(), new IllegalArgumentException(sb.toString()));
+			}
 
 			Resource individualResource = resources.get(0);
 
@@ -905,8 +910,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					resourceBlockIdsBag);
 			}
 
-			primKey = fixLegacyPrimaryKey(companyId, name, primKey);
-
 			List<Resource> resources = getResources(
 				companyId, groupId, name, primKey, actionId);
 
@@ -973,8 +976,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			companyId = group.getCompanyId();
 		}
-
-		primKey = fixLegacyPrimaryKey(companyId, name, primKey);
 
 		try {
 			boolean hasPermission = doCheckPermission(

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -713,46 +713,28 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return resources;
 		}
 
+		String newIndividualResourcePrimKey = null;
+
 		if ((groupId > 0) && ResourceActionsUtil.isRootModelResource(name)) {
 
 			// There are no custom permissions defined for root model-resource,
 			// use defaults
 
-			Resource individualResource = resources.get(0);
-
-			if (individualResource.getScope() !=
-					ResourceConstants.SCOPE_INDIVIDUAL) {
-
-				throw new IllegalArgumentException(
-					"The first resource must be an individual scope");
-			}
-
-			individualResource.setPrimKey(name);
-
-			return resources;
+			newIndividualResourcePrimKey = name;
 		}
 
-		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+		else if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
 
 			// There are no custom permissions defined for portlet, use defaults
 
-			Resource individualResource = resources.get(0);
-
-			if (individualResource.getScope() !=
-				ResourceConstants.SCOPE_INDIVIDUAL) {
-
-				throw new IllegalArgumentException(
-					"The first resource must be an individual scope");
-			}
-
-			individualResource.setPrimKey(name);
-
-			return resources;
+			newIndividualResourcePrimKey = name;
 		}
 
-		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
-			(primKey.equals(String.valueOf(companyId)) &&
-				!name.equals(Company.class.getName()))) {
+		else if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+				 (primKey.equals(String.valueOf(companyId)) &&
+				  !name.equals(Company.class.getName()))) {
+
+			newIndividualResourcePrimKey = name;
 
 			if (_log.isWarnEnabled()) {
 				StringBundler sb = new StringBundler(9);
@@ -770,19 +752,19 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				_log.warn(
 					sb.toString(), new IllegalArgumentException(sb.toString()));
 			}
+		}
 
+		if (newIndividualResourcePrimKey != null) {
 			Resource individualResource = resources.get(0);
 
 			if (individualResource.getScope() !=
-				ResourceConstants.SCOPE_INDIVIDUAL) {
+					ResourceConstants.SCOPE_INDIVIDUAL) {
 
 				throw new IllegalArgumentException(
 					"The first resource must be an individual scope");
 			}
 
 			individualResource.setPrimKey(name);
-
-			return resources;
 		}
 
 		return resources;

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -586,6 +586,12 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	@Override
+	public String[] getRootModelResources() {
+		return _rootModelResources.toArray(
+			new String[_rootModelResources.size()]);
+	}
+
+	@Override
 	public boolean hasModelResourceActions(String name) {
 		ModelResourceActionsBag modelResourceActionsBag =
 			getModelResourceActionsBag(name);
@@ -613,6 +619,16 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public boolean isPortalModelResource(String modelResource) {
 		if (_portalModelResources.contains(modelResource)) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean isRootModelResource(String modelResource) {
+		if (_rootModelResources.contains(modelResource)) {
 			return true;
 		}
 		else {
@@ -1109,6 +1125,8 @@ public class ResourceActionsImpl implements ResourceActions {
 				modelResourceElement.elementText("root"));
 
 			if (root) {
+				_rootModelResources.add(name);
+
 				Map<String, String> portletRootModelResource =
 					portletResourceActionsBag.getPortletRootModelResources();
 
@@ -1270,5 +1288,6 @@ public class ResourceActionsImpl implements ResourceActions {
 	private Map<String, PortletResourceActionsBag> _portletResourceActionsBags;
 	private final ServiceTrackerList<ResourceBundleLoader>
 		_resourceBundleLoaders;
+	private final Set<String> _rootModelResources = new HashSet<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -150,6 +150,8 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 	public void checkPortlet(Portlet portlet) throws PortalException {
 		initPortletDefaultPermissions(portlet);
 
+		initPortletRootModelDefaultPermissions(portlet);
+
 		initPortletModelDefaultPermissions(portlet);
 
 		initPortletAddToPagePermissions(portlet);
@@ -1185,6 +1187,47 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				portlet.getCompanyId(), 0, 0, modelResource, modelResource,
 				false, false, true);
 		}
+	}
+
+	protected void initPortletRootModelDefaultPermissions(Portlet portlet)
+		throws PortalException {
+
+		String rootModel = ResourceActionsUtil.getPortletRootModelResource(
+			portlet.getRootPortletId());
+
+		if (Validator.isBlank(rootModel)) {
+			return;
+		}
+
+		Role guestRole = roleLocalService.getRole(
+			portlet.getCompanyId(), RoleConstants.GUEST);
+		List<String> guestActions =
+			ResourceActionsUtil.getModelResourceGuestDefaultActions(rootModel);
+
+		resourcePermissionLocalService.setResourcePermissions(
+			portlet.getCompanyId(), rootModel,
+			ResourceConstants.SCOPE_INDIVIDUAL, rootModel,
+			guestRole.getRoleId(), guestActions.toArray(new String[0]));
+
+		Role ownerRole = roleLocalService.getRole(
+			portlet.getCompanyId(), RoleConstants.OWNER);
+		List<String> ownerActionIds =
+			ResourceActionsUtil.getModelResourceActions(rootModel);
+
+		resourcePermissionLocalService.setOwnerResourcePermissions(
+			portlet.getCompanyId(), rootModel,
+			ResourceConstants.SCOPE_INDIVIDUAL, rootModel,
+			ownerRole.getRoleId(), 0, ownerActionIds.toArray(new String[0]));
+
+		Role siteMemberRole = roleLocalService.getRole(
+			portlet.getCompanyId(), RoleConstants.SITE_MEMBER);
+		List<String> groupActionIds =
+			ResourceActionsUtil.getModelResourceGroupDefaultActions(rootModel);
+
+		resourcePermissionLocalService.setResourcePermissions(
+			portlet.getCompanyId(), rootModel,
+			ResourceConstants.SCOPE_INDIVIDUAL, rootModel,
+			siteMemberRole.getRoleId(), groupActionIds.toArray(new String[0]));
 	}
 
 	protected void readLiferayDisplay(

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletConstants;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -33,7 +32,6 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermission;
@@ -341,21 +339,6 @@ public class PortletPermissionImpl implements PortletPermission {
 		}
 
 		resourcePermissionPrimKey = getPrimaryKey(layout.getPlid(), portletId);
-
-		boolean useDefaultPortletPermissions = false;
-
-		int count =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				permissionChecker.getCompanyId(), rootPortletId,
-				ResourceConstants.SCOPE_INDIVIDUAL, resourcePermissionPrimKey);
-
-		if (count == 0) {
-			useDefaultPortletPermissions = true;
-		}
-
-		if (useDefaultPortletPermissions) {
-			resourcePermissionPrimKey = rootPortletId;
-		}
 
 		if (strict) {
 			return permissionChecker.hasPermission(

--- a/portal-impl/src/com/liferay/portlet/announcements/service/permission/AnnouncementsEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/permission/AnnouncementsEntryPermission.java
@@ -18,12 +18,10 @@ import com.liferay.announcements.kernel.model.AnnouncementsEntry;
 import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 
 /**
@@ -105,23 +103,8 @@ public class AnnouncementsEntryPermission {
 			layout = virtualLayout.getSourceLayout();
 		}
 
-		boolean useDefaultPortletPermissions = false;
-
 		String primKey = PortletPermissionUtil.getPrimaryKey(
 			layout.getPlid(), portletId);
-
-		int count =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				permissionChecker.getCompanyId(), portletId,
-				ResourceConstants.SCOPE_INDIVIDUAL, primKey);
-
-		if (count == 0) {
-			useDefaultPortletPermissions = true;
-		}
-
-		if (useDefaultPortletPermissions) {
-			primKey = portletId;
-		}
 
 		return permissionChecker.hasPermission(
 			layout.getGroupId(), portletId, primKey, actionId);

--- a/portal-impl/src/resource-actions/asset.xml
+++ b/portal-impl/src/resource-actions/asset.xml
@@ -25,6 +25,7 @@
 		<portlet-ref>
 			<portlet-name>com_liferay_asset_categories_admin_web_portlet_AssetCategoriesAdminPortlet</portlet-name>
 		</portlet-ref>
+		<root>true</root>
 		<weight>1</weight>
 		<permissions>
 			<supports>

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -122,6 +122,12 @@ public class PermissionCheckerTest {
 				_PORTLET_RESOURCE_NAME, ActionKeys.ACCESS_IN_CONTROL_PANEL);
 
 			Assert.assertFalse(hasPermission);
+
+			hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _ROOT_MODEL_RESOURCE_NAME,
+				_ROOT_MODEL_RESOURCE_NAME, _ADD_SITE_TEST_ACTION);
+
+			Assert.assertTrue(hasPermission);
 		}
 		finally {
 			destroyRemotePortlet(_user.getCompanyId(), _PORTLET_RESOURCE_NAME);
@@ -190,6 +196,12 @@ public class PermissionCheckerTest {
 	public void testHasPermissionOnRootModelResource() throws Exception {
 		_user = UserTestUtil.addUser();
 
+		_role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_SITE);
+
+		UserLocalServiceUtil.setRoleUsers(
+			_role.getRoleId(), new long[] {_user.getUserId()});
+
 		PermissionChecker permissionChecker = _getPermissionChecker(_user);
 
 		ResourceLocalServiceUtil.addResources(
@@ -213,6 +225,31 @@ public class PermissionCheckerTest {
 				_group.getGroupId(), _ADD_SITE_TEST_ACTION);
 
 			Assert.assertTrue(hasPermission);
+
+			hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _ROOT_MODEL_RESOURCE_NAME,
+				_group.getGroupId(), _ADD_SITE_TEST2_ACTION);
+
+			Assert.assertFalse(hasPermission);
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _ROOT_MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(_group.getGroupId()), _role.getRoleId(),
+				new String[] {_ADD_SITE_TEST2_ACTION});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					_group.getGroupId(), _ROOT_MODEL_RESOURCE_NAME,
+					_group.getGroupId(), _ADD_SITE_TEST2_ACTION);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _ROOT_MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_INDIVIDUAL, _group.getGroupId());
+			}
 		}
 		finally {
 			ResourceLocalServiceUtil.deleteResource(
@@ -909,6 +946,8 @@ public class PermissionCheckerTest {
 	}
 
 	private static final String _ADD_SITE_TEST_ACTION = "ADD_SITE_TEST";
+
+	private static final String _ADD_SITE_TEST2_ACTION = "ADD_SITE_TEST2";
 
 	private static final String _ADD_TEST_ACTION = "ADD_TEST";
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
@@ -60,6 +60,7 @@
 		<permissions>
 			<supports>
 				<action-key>ADD_SITE_TEST</action-key>
+				<action-key>ADD_SITE_TEST2</action-key>
 			</supports>
 			<site-member-defaults>
 				<action-key>ADD_SITE_TEST</action-key>

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/BaseResourcePermissionChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/BaseResourcePermissionChecker.java
@@ -18,10 +18,7 @@ import com.liferay.exportimport.kernel.staging.permission.StagingPermissionUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 
 /**
  * @author Preston Crary
@@ -37,25 +34,6 @@ public abstract class BaseResourcePermissionChecker
 
 		if ((group != null) && group.isStagingGroup()) {
 			classPK = group.getLiveGroupId();
-		}
-
-		try {
-			int count =
-				ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-					permissionChecker.getCompanyId(), name,
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(classPK));
-
-			if (count == 0) {
-				ResourceLocalServiceUtil.addResources(
-					permissionChecker.getCompanyId(), classPK, 0, name, classPK,
-					false, true, true);
-			}
-		}
-		catch (Exception e) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(e, e);
-			}
 		}
 
 		return permissionChecker.hasPermission(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -161,11 +161,15 @@ public interface ResourceActions {
 	public List<Role> getRoles(
 		long companyId, Group group, String modelResource, int[] roleTypes);
 
+	public String[] getRootModelResources();
+
 	public boolean hasModelResourceActions(String name);
 
 	public boolean isOrganizationModelResource(String modelResource);
 
 	public boolean isPortalModelResource(String modelResource);
+
+	public boolean isRootModelResource(String modelResource);
 
 	public void read(
 			String servletContextName, ClassLoader classLoader, String source)

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActionsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActionsUtil.java
@@ -263,6 +263,10 @@ public class ResourceActionsUtil {
 			companyId, group, modelResource, roleTypes);
 	}
 
+	public static String[] getRootModelResources() {
+		return getResourceActions().getRootModelResources();
+	}
+
 	public static boolean hasModelResourceActions(String name) {
 		return getResourceActions().hasModelResourceActions(name);
 	}
@@ -280,6 +284,10 @@ public class ResourceActionsUtil {
 
 	public static boolean isPortalModelResource(String modelResource) {
 		return getResourceActions().isPortalModelResource(modelResource);
+	}
+
+	public static boolean isRootModelResource(String modelResource) {
+		return getResourceActions().isRootModelResource(modelResource);
 	}
 
 	public static void read(


### PR DESCRIPTION
Hi Ray,

here I'm fixing the issue that for each group we need separate resource permission records for root model-resource (com.liferay.journal, com.liferay.blogs, ...).

We have 2 kinds of root model-resource scenarios:
1, non-site use - the old way with portlets that are not scoped to site and use `permissionChecker.hasPermission(0, "com.something.model", "com.something.model", "ADD_ASDF")`
2, site related permissions which can modified differently for each site - we use `permissionChecker.hasPermission(groupId, "com.something.site.model", groupId, "ADD_ASDF")`

So for the 2nd type we create (created) individual record per-site (primKey = groupId) so that it can be modified on each site. However, it required developers to programatically create the record which is in fact done by extending `BaseResourcePermissionChecker`. But not everybody knows that, I'd say almost nobody except @juliocamarero and @JorgeFerrer :)

Here I create defaults per-company. I use them when the groupId record is not found so now we don't need to have the per-group records, which in most cases duplicated the defaults only.

This no longer requires developers to extend BaseResourcePermissionChecker, only to declare the root models as `<root>true</root>` in resource-actions.xml, as it should be.

Thanks.