### PR TITLE
LPS-64800

### DIFF
--- a/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspBundleClassloader.java
+++ b/modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspBundleClassloader.java
@@ -95,7 +95,9 @@ public class JspBundleClassloader extends URLClassLoader {
 			}
 		}
 
-		throw new ClassNotFoundException(name);
+		ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+
+		return systemClassLoader.loadClass(name);
 	}
 
 	@Override

--- a/modules/apps/foundation/portal/portal-spring-extender/src/main/java/com/liferay/portal/spring/extender/internal/classloader/BundleResolverClassLoader.java
+++ b/modules/apps/foundation/portal/portal-spring-extender/src/main/java/com/liferay/portal/spring/extender/internal/classloader/BundleResolverClassLoader.java
@@ -58,7 +58,9 @@ public class BundleResolverClassLoader extends ClassLoader {
 			}
 		}
 
-		throw new ClassNotFoundException(name);
+		ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+
+		return systemClassLoader.loadClass(name);
 	}
 
 	@Override


### PR DESCRIPTION
I don't understand why you would deny access to system classloader classes like javax.net.ssl.SSLContext (which was the reason an exception was thrown in this case) so this fix made the most sense to me. If there's another way you'd prefer us to fix it, please let us know.

https://issues.liferay.com/browse/LPS-64800