### PR TITLE
[TECHNICAL SUPPORT] LPS-63922 User-specific portlet preferences are not cleaned up when the portlet is removed and portlet can not be re-added

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1124,11 +1124,39 @@ ${output.content}</echo>
 						<if>
 							<isset property="modules.base.dir.names.with.changes" />
 							<then>
-								<for list="${modules.base.dir.names.with.changes}" param="modules.base.dir.name">
+								<for list="${modules.base.dir.names.with.changes}" param="module.base.dir.name">
 									<sequential>
-										<echo>Executing baseline on @{modules.base.dir.name}.</echo>
+										<var name="module.baseline.task.name" unset="true" />
+										<var name="modules.base.dir.name" unset="true" />
 
-										<gradle-execute dir="@{modules.base.dir.name}" forcedcacheenabled="false" task="baseline" />
+										<propertyregex
+											input="@{module.base.dir.name}"
+											override="true"
+											property="modules.base.dir.name"
+											regexp="(.*/modules)(/.*)"
+											replace="\1"
+										/>
+
+										<propertyregex
+											input="@{module.base.dir.name}"
+											override="true"
+											property="module.baseline.task.name"
+											regexp="(.*/modules)(/.*)"
+											replace="\2"
+										/>
+
+										<antelope:stringutil property="module.baseline.task.name" string="${module.baseline.task.name}">
+											<antelope:replace regex="/" replacement=":" />
+										</antelope:stringutil>
+
+										<var name="module.baseline.task.name" value="${module.baseline.task.name}:baseline" />
+
+										<echo>Executing ${module.baseline.task.name} on ${modules.base.dir.name}.</echo>
+
+										<gradle-execute dir="${modules.base.dir.name}" forcedcacheenabled="false" task="${module.baseline.task.name}" />
+
+										<var name="module.baseline.task.name" unset="true" />
+										<var name="modules.base.dir.name" unset="true" />
 									</sequential>
 								</for>
 							</then>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -50,6 +50,7 @@ page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileShortcut" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileVersion" %><%@
 page import="com.liferay.portal.kernel.repository.model.Folder" %><%@
+page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.util.ClassUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
@@ -60,6 +61,7 @@ page import="com.liferay.portal.kernel.util.TextFormatter" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
+page import="com.liferay.portlet.documentlibrary.service.permission.DLFolderPermission" %><%@
 page import="com.liferay.portlet.usersadmin.search.GroupSearch" %>
 
 <%@ page import="java.util.HashMap" %><%@

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -169,7 +169,7 @@ if (Validator.isNotNull(keywords)) {
 	}
 	%>
 
-	<c:if test="<%= showDragAndDropZone && !showSearchInfo %>">
+	<c:if test="<%= showDragAndDropZone && !showSearchInfo && DLFolderPermission.contains(permissionChecker, scopeGroupId, folderId, ActionKeys.ADD_DOCUMENT) %>">
 		<liferay-util:buffer var="selectFileHTML">
 			<label class="btn btn-default" for="<%= randomNamespace %>InputFile"><liferay-ui:message key="select-file" /></label>
 

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet_processes.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet_processes.jsp
@@ -91,21 +91,23 @@ OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFa
 
 		<liferay-ui:search-container-column-text>
 			<c:if test="<%= !backgroundTask.isInProgress() %>">
+				<liferay-ui:icon-menu direction="left-side" icon="<%= StringPool.BLANK %>" markupView="lexicon" message="<%= StringPool.BLANK %>" showWhenSingleIcon="<%= true %>">
 
-				<%
-				Date completionDate = backgroundTask.getCompletionDate();
-				%>
+					<%
+					Date completionDate = backgroundTask.getCompletionDate();
+					%>
 
-				<liferay-portlet:actionURL name="deleteBackgroundTask" portletName="<%= PortletKeys.EXPORT_IMPORT %>" var="deleteBackgroundTaskURL">
-					<portlet:param name="redirect" value="<%= portletURL.toString() %>" />
-					<portlet:param name="backgroundTaskId" value="<%= String.valueOf(backgroundTask.getBackgroundTaskId()) %>" />
-				</liferay-portlet:actionURL>
+					<liferay-portlet:actionURL name="deleteBackgroundTask" portletName="<%= PortletKeys.EXPORT_IMPORT %>" var="deleteBackgroundTaskURL">
+						<portlet:param name="redirect" value="<%= portletURL.toString() %>" />
+						<portlet:param name="backgroundTaskId" value="<%= String.valueOf(backgroundTask.getBackgroundTaskId()) %>" />
+					</liferay-portlet:actionURL>
 
-				<liferay-ui:icon-delete
-					label="<%= true %>"
-					message='<%= ((completionDate != null) && completionDate.before(new Date())) ? "clear" : "cancel" %>'
-					url="<%= deleteBackgroundTaskURL %>"
-				/>
+					<liferay-ui:icon-delete
+						label="<%= true %>"
+						message='<%= ((completionDate != null) && completionDate.before(new Date())) ? "clear" : "cancel" %>'
+						url="<%= deleteBackgroundTaskURL %>"
+					/>
+				</liferay-ui:icon-menu>
 			</c:if>
 		</liferay-ui:search-container-column-text>
 	</liferay-ui:search-container-row>

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/add_button.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/add_button.jsp
@@ -20,7 +20,7 @@
 int configurationType = ExportImportConfigurationConstants.TYPE_PUBLISH_LAYOUT_LOCAL;
 boolean localPublishing = true;
 
-if (stagingGroup.hasRemoteStagingGroup()) {
+if (stagingGroup.isStagedRemotely()) {
 	configurationType = ExportImportConfigurationConstants.TYPE_PUBLISH_LAYOUT_REMOTE;
 	localPublishing = false;
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -219,15 +219,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			companyId, rootPortletId, ResourceConstants.SCOPE_INDIVIDUAL,
 			PortletPermissionUtil.getPrimaryKey(plid, portletId));
 
-		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-
-		if (PortletConstants.hasUserId(portletId)) {
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-		}
-
 		List<PortletPreferences> portletPreferencesList =
 			portletPreferencesLocalService.getPortletPreferences(
-				ownerType, plid, portletId);
+				plid, portletId);
 
 		Portlet portlet = getPortletById(companyId, portletId);
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionFinderImpl.java
@@ -63,7 +63,7 @@ public class ResourcePermissionFinderImpl
 			ResourcePermissionModelImpl.ENTITY_CACHE_ENABLED,
 			ResourcePermissionModelImpl.FINDER_CACHE_ENABLED, Long.class,
 			ResourcePermissionPersistenceImpl.
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
 			"countByC_N_S_P_R_A",
 			new String[] {
 				Long.class.getName(), String.class.getName(),

--- a/portal-impl/src/com/liferay/portlet/MimeResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/MimeResponseImpl.java
@@ -116,7 +116,7 @@ public abstract class MimeResponseImpl
 
 	@Override
 	public boolean isCommitted() {
-		return false;
+		return _response.isCommitted();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/ratings/service/persistence/impl/RatingsEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/persistence/impl/RatingsEntryFinderImpl.java
@@ -47,7 +47,7 @@ public class RatingsEntryFinderImpl
 	public static final FinderPath FINDER_PATH_FIND_BY_U_C_C = new FinderPath(
 		RatingsEntryModelImpl.ENTITY_CACHE_ENABLED,
 		RatingsEntryModelImpl.FINDER_CACHE_ENABLED, RatingsEntryImpl.class,
-		RatingsEntryPersistenceImpl.FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+		RatingsEntryPersistenceImpl.FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
 		"findByU_C_C",
 		new String[] {
 			Long.class.getName(), Long.class.getName(), List.class.getName()

--- a/portal-impl/src/com/liferay/portlet/ratings/service/persistence/impl/RatingsStatsFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/persistence/impl/RatingsStatsFinderImpl.java
@@ -47,7 +47,7 @@ public class RatingsStatsFinderImpl
 	public static final FinderPath FINDER_PATH_FIND_BY_C_C = new FinderPath(
 		RatingsStatsModelImpl.ENTITY_CACHE_ENABLED,
 		RatingsStatsModelImpl.FINDER_CACHE_ENABLED, RatingsStatsImpl.class,
-		RatingsStatsPersistenceImpl.FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+		RatingsStatsPersistenceImpl.FINDER_CLASS_NAME_LIST_WITH_PAGINATION,
 		"findByC_C",
 		new String[] {Long.class.getName(), List.class.getName()});
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Organization.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Organization.macro
@@ -363,6 +363,10 @@
 		<execute function="AssertClick" locator1="UsersAndOrganizationsAssignOrganizationalRoles#CURRENT_TAB" value1="Current" />
 		<execute function="AssertTextEquals" locator1="CPUsersandorganizationsAssignuserrolesUser#USER_TABLE_USER_NAME" value1="${userFirstName} ${userLastName}" />
 		<execute function="AssertTextEquals" locator1="CPUsersandorganizationsAssignuserrolesUser#USER_TABLE_SCREEN_NAME" value1="${userScreenName}" />
+
+		<execute function="SelectFrame" value1="relative=top" />
+
+		<execute function="Click" locator1="Icon#CLOSE" />
 	</command>
 
 	<command name="deleteCP">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -643,7 +643,7 @@
 			<var name="portlet" value="Staging" />
 		</execute>
 
-		<execute function="AssertTextEquals" locator1="StagingPublishToLive#CURRENT_AND_PREVIOUS_TABLE_STATUS" value1="Successful" />
+		<execute function="AssertTextEquals" locator1="Staging#STAGING_STATUS" value1="Successful" />
 	</command>
 
 	<command name="redoStagingPageVersioningPG">

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/Staging.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/Staging.path
@@ -52,7 +52,7 @@
 </tr>
 <tr>
 	<td>STAGING_STATUS</td>
-	<td>//tr/td[contains(@class,'status-column')]</td>
+	<td>xpath=(//h6[contains(text(),'Successful')])[1]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
@@ -919,6 +919,10 @@
 			<var name="siteName" value="Site Name" />
 		</execute>
 
+		<execute macro="ProductMenu#gotoSitesContent">
+			<var name="portlet" value="Documents and Media" />
+		</execute>
+
 		<execute macro="DMNavigator#gotoDocumentType" />
 
 		<execute macro="DMDocumentType#add">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecase.testcase
@@ -2904,6 +2904,11 @@
 			<var name="portlet" value="Web Content" />
 		</execute>
 
+		<execute macro="Navigator#gotoStagedSitePage">
+			<var name="pageName" value="Staging Test Page" />
+			<var name="siteName" value="Site Name" />
+		</execute>
+
 		<execute macro="Staging#viewPublishContentCountViaPortletStagingCP">
 			<var name="contentCount" value="1" />
 			<var name="contentInformation" value="Web Content (1)" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-63922

Hi Ray,

See Norbert's comment:
>Use cases to consider:
1. Preferences-unique-per-layout=true preferences-owned-by-group=true
plid+portletId will be unique in this case and that record should be removed.
2. Preferences-unique-per-layout=true preferences-owned-by-group=false
This is what the issue is about. In this case there will be one record for the layout owned by the group, and one owned by each user who configures the portlet. Every one of those needs to be removed.
3. The column is customizable.
plid+portletId will be unique (portletId + userId separator + userId) in this case and that record has to be romoved

>In other cases the preferences won't be related to the layout so they won't be removed.

I've asked him to create a test for this. We'll submit if you agree with his changes.

Thanks,
Tibor

/cc @NorbertKocsis