### PR TITLE
LPS-65488

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6538,7 +6538,22 @@
 
     module.framework.properties.org.osgi.framework.bootdelegation=\
         __redirected,\
+        com.sun.ccpp,\
+        com.sun.ccpp.*,\
+        com.sun.crypto.*,\
+        com.sun.el,\
+        com.sun.el.*,\
+        com.sun.image.*,\
+        com.sun.jmx.*,\
         com.sun.jna,\
+        com.sun.jndi.*,\
+        com.sun.mail.*,\
+        com.sun.management.*,\
+        com.sun.media.*,\
+        com.sun.msv.*,\
+        com.sun.org.*,\
+        com.sun.syndication.*,\
+        com.sun.tools.*,\
         com.sun.xml.*,\
         com.yourkit.*,\
         sun.*

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6538,7 +6538,8 @@
 
     module.framework.properties.org.osgi.framework.bootdelegation=\
         __redirected,\
-        com.sun.*,\
+        com.sun.jna.*,\
+        com.sun.xml.*,\
         com.yourkit.*,\
         sun.*
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6538,7 +6538,7 @@
 
     module.framework.properties.org.osgi.framework.bootdelegation=\
         __redirected,\
-        com.sun.jna.*,\
+        com.sun.jna,\
         com.sun.xml.*,\
         com.yourkit.*,\
         sun.*


### PR DESCRIPTION
Hi @rotty3000. This causes issues on servers that already have bundled JSF versions so the wrong JSF impl. was picked up (com.sun.faces.*).

As this part doesn't have any mechanism for negating a package (!com.sun.faces...) we should add the needed ones except com.sun.faces.*.

I've searched through portal and added com.sun packages that were used (com.sun.jna and com.sun.crypto are needed for sure). Hopefully is enough and it doesn't break anything.

Thanks!

/cc @stiemannkj1