### PR TITLE
LPS-66660

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/SecureServlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/SecureServlet.java
@@ -61,6 +61,10 @@ public class SecureServlet
 
 	@Override
 	public String getServletInfo() {
+		if (servlet == null) {
+			return "";
+		}
+
 		return servlet.getServletInfo();
 	}
 


### PR DESCRIPTION
Hey @rotty3000,

The issue is that in Equinox, the servlet's info is gathered before the servlet is initialized:

https://github.com/eclipse/rt.equinox.bundles/blob/master/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ContextController.java#L540-L600

At the beginning of the block its calling ```servletHolder.get().getServletInfo()``` and then at the end it calls ```servletRegistration.init(servletConfig)```

I went ahead and made the SecureServlet a bit more robust, but let me know if there's a better way to fix this so that the servlet info can be gathered.

Thanks!