### PR TITLE
[TECHNICAL-SUPPORT] LPS-69446

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
@@ -289,9 +289,7 @@ public class ServletContextHelperRegistrationImpl
 			return contextPath;
 		}
 
-		String symbolicName = _bundle.getSymbolicName();
-
-		return '/' + symbolicName.replaceAll("[^a-zA-Z0-9]", "");
+		return '/' + _bundle.getSymbolicName();
 	}
 
 	protected String getServletContextName(String contextPath) {
@@ -303,9 +301,7 @@ public class ServletContextHelperRegistrationImpl
 			return header;
 		}
 
-		contextPath = contextPath.substring(1);
-
-		return contextPath.replaceAll("[^a-zA-Z0-9\\-]", "");
+		return contextPath.substring(1);
 	}
 
 	protected void registerServletContext() {

--- a/portal-kernel/src/com/liferay/portal/kernel/bean/PortletBeanLocatorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/bean/PortletBeanLocatorUtil.java
@@ -17,7 +17,6 @@ package com.liferay.portal.kernel.bean;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,18 +39,13 @@ public class PortletBeanLocatorUtil {
 		BeanLocator beanLocator = getBeanLocator(servletContextName);
 
 		if (beanLocator == null) {
-			beanLocator = getBeanLocator(
-				StringUtil.strip(servletContextName, '.'));
+			_log.error(
+				"BeanLocator is null for servlet context " +
+					servletContextName);
 
-			if (beanLocator == null) {
-				_log.error(
-					"BeanLocator is null for servlet context " +
-						servletContextName);
-
-				throw new BeanLocatorException(
-					"BeanLocator is not set for servlet context " +
-						servletContextName);
-			}
+			throw new BeanLocatorException(
+				"BeanLocator is not set for servlet context " +
+					servletContextName);
 		}
 
 		return beanLocator.locate(name);


### PR DESCRIPTION
From @NolanChan

> This fix replaces the previous fix connected to [LPS-69104](https://github.com/brianchandotcom/liferay-portal/pull/44871): 
> 
> After extensive testing, searching, and help from @Preston-Crary, I discovered that Liferay's filtering of OSGI custom portlet context [names](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java#L308) & [paths](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java#L294) are unnecessary due to our implementation of [Equinox OSGI already filtering out improper characters in the context name](https://git.eclipse.org/c/equinox/rt.equinox.bundles.git/commit/?id=34c2425bdadb56dad5e6453415ecf58de0d158a8). Therefore, we can get rid of the unnecessary character stripping which is causing our customers' problems.