### PR TITLE
[TECHNICAL-SUPPORT] LPS-74956

### DIFF
--- a/portal-impl/src/com/liferay/portal/plugin/PluginPackageUtil.java
+++ b/portal-impl/src/com/liferay/portal/plugin/PluginPackageUtil.java
@@ -897,7 +897,17 @@ public class PluginPackageUtil {
 				moduleVersion = displayName.substring(moduleVersionPos);
 			}
 			else {
-				moduleVersion = ReleaseInfo.getVersion();
+				String moduleIncrementalVersion = GetterUtil.getString(
+					properties.getProperty("module-incremental-version"));
+
+				if (Validator.isNull(moduleIncrementalVersion)) {
+					moduleVersion = ReleaseInfo.getVersion();
+				}
+				else {
+					moduleVersion =
+						ReleaseInfo.getVersion() + "." +
+							moduleIncrementalVersion;
+				}
 			}
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/deploy/auto/AutoDeployDir.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/deploy/auto/AutoDeployDir.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Ivica Cardic
@@ -103,6 +105,12 @@ public class AutoDeployDir {
 
 					break;
 				}
+			}
+
+			Matcher matcher = _VERSION_PATTERN.matcher(fileName);
+
+			if (matcher.find()) {
+				fileName = matcher.replaceFirst(".war");
 			}
 		}
 		else {
@@ -320,6 +328,9 @@ public class AutoDeployDir {
 			}
 		}
 	}
+
+	private static final Pattern _VERSION_PATTERN = Pattern.compile(
+		"-[\\d]+((\\.[\\d]+)+(-SNAPSHOT)?)\\.war$");
 
 	private static final Log _log = LogFactoryUtil.getLog(AutoDeployDir.class);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PluginContextListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PluginContextListener.java
@@ -40,6 +40,12 @@ public class PluginContextListener
 	public void attributeAdded(
 		ServletContextAttributeEvent servletContextAttributeEvent) {
 
+		if (servletContextAttributeEvent.getServletContext() !=
+				servletContext) {
+
+			return;
+		}
+
 		String name = servletContextAttributeEvent.getName();
 
 		if (_addedPluginClassLoader && name.equals(PLUGIN_CLASS_LOADER) &&
@@ -61,6 +67,12 @@ public class PluginContextListener
 	public void attributeRemoved(
 		ServletContextAttributeEvent servletContextAttributeEvent) {
 
+		if (servletContextAttributeEvent.getServletContext() !=
+				servletContext) {
+
+			return;
+		}
+
 		String name = servletContextAttributeEvent.getName();
 
 		if (_addedPluginClassLoader && name.equals(PLUGIN_CLASS_LOADER)) {
@@ -75,6 +87,12 @@ public class PluginContextListener
 	@Override
 	public void attributeReplaced(
 		ServletContextAttributeEvent servletContextAttributeEvent) {
+
+		if (servletContextAttributeEvent.getServletContext() !=
+				servletContext) {
+
+			return;
+		}
 
 		String name = servletContextAttributeEvent.getName();
 


### PR DESCRIPTION
Hey @rotty3000,

These changes will allow WARs to be deployed like they used to be on 6.2. We will now strip out the version (if there is one) from the filename. Since we do that, newly deployed WARs will now overwrite previous ones and only one bundle will be available.

Please let me know if you have any questions or concerns about the solution.

Thanks.