### PR TITLE
[TECHNICAL-SUPPORT] LPS-79313

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4072,7 +4072,12 @@ public class PortalImpl implements Portal {
 		}
 
 		if (inetSocketAddress == null) {
-			return -1;
+			if (secure) {
+				return PropsValues.WEB_SERVER_HTTPS_PORT;
+			}
+			else {
+				return PropsValues.WEB_SERVER_HTTP_PORT;
+			}
 		}
 
 		return inetSocketAddress.getPort();


### PR DESCRIPTION
/cc @Alec-Shay

Notes from Alec:

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-29528
> https://issues.liferay.com/browse/LPS-79313
> 
> If two bundles of Liferay are configured to use virtual hosts with different domain names, then depending on the properties used, Liferay may fail to replace URL links when exporting and re-importing a LAR with web content between them.
> 
> The main issue appears to be that Liferay is ignoring the configured values for the port, making it exit early from `LayoutReferencesExportImportContentProcessor.replaceExportHostname()` (which is supposed to replace the host name in the URL). Replacing this allows the domain name of the URL to be replaced, which fixes this issue.

>We also noticed when working on this that [this method in LayoutReferencesExportImportContentProcessor](https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java#L197) seems to have a really confusing flow of execution (it has multiple calls to `replaceExportHostname()` that not only use different types of data, but cannot be called using the same types of data, so different parts of the method must be executed for different types of String values), so it seems like this may cause problems for maintenance in the long term. However, we did not identify any particular problems that this was causing, so addressing that was out of the scope of fixing this issue.