### PR TITLE
LPS-93568 Removing one Rest Extender endpoint configuration from node1 deletes all endpoint configurations from node2

### DIFF
--- a/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/ConfigurationSynchronousConfigurationListener.java
+++ b/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/ConfigurationSynchronousConfigurationListener.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.Message;
 
 import org.osgi.framework.Constants;
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationEvent;
 import org.osgi.service.cm.SynchronousConfigurationListener;
 import org.osgi.service.component.annotations.Component;
@@ -44,12 +43,6 @@ public class ConfigurationSynchronousConfigurationListener
 
 		message.setDestinationName(
 			ConfigurationClusterDestinationNames.CONFIGURATION);
-
-		String factoryPid = configurationEvent.getFactoryPid();
-
-		if (factoryPid != null) {
-			message.put(ConfigurationAdmin.SERVICE_FACTORYPID, factoryPid);
-		}
 
 		message.put(Constants.SERVICE_PID, configurationEvent.getPid());
 

--- a/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
+++ b/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
@@ -51,18 +51,9 @@ public class ConfigurationMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		if (message.contains(ConfigurationAdmin.SERVICE_FACTORYPID)) {
-			reloadConfiguration(
-				message.getString(ConfigurationAdmin.SERVICE_FACTORYPID),
-				ConfigurationAdmin.SERVICE_FACTORYPID,
-				message.getInteger("configuration.event.type"));
-		}
-
-		if (message.contains(Constants.SERVICE_PID)) {
-			reloadConfiguration(
-				message.getString(Constants.SERVICE_PID), Constants.SERVICE_PID,
-				message.getInteger("configuration.event.type"));
-		}
+		reloadConfiguration(
+			message.getString(Constants.SERVICE_PID), Constants.SERVICE_PID,
+			message.getInteger("configuration.event.type"));
 	}
 
 	protected void reloadConfiguration(String pid, String filter, int type)

--- a/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
+++ b/modules/apps/portal-configuration/portal-configuration-cluster/src/main/java/com/liferay/portal/configuration/cluster/internal/messaging/ConfigurationMessageListener.java
@@ -52,17 +52,15 @@ public class ConfigurationMessageListener extends BaseMessageListener {
 	@Override
 	protected void doReceive(Message message) throws Exception {
 		reloadConfiguration(
-			message.getString(Constants.SERVICE_PID), Constants.SERVICE_PID,
+			message.getString(Constants.SERVICE_PID),
 			message.getInteger("configuration.event.type"));
 	}
 
-	protected void reloadConfiguration(String pid, String filter, int type)
-		throws Exception {
-
+	protected void reloadConfiguration(String pid, int type) throws Exception {
 		StringBundler sb = new StringBundler(5);
 
 		sb.append("(");
-		sb.append(filter);
+		sb.append(Constants.SERVICE_PID);
 		sb.append("=");
 		sb.append(pid);
 		sb.append(")");


### PR DESCRIPTION
This is an update for [LPS-93568](https://issues.liferay.com/browse/LPS-93568).<br><br>/cc @pei-jung @stsquared99 @alee8888 @ChrisKian @jrao