### PR TITLE
LCD-14361 We already have the dependency as compileOnly, adding testCompile is redundant

### DIFF
--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle
@@ -44,6 +44,4 @@ dependencies {
 	compileOnly project(":apps:static:portal-file-install:portal-file-install-api")
 	compileOnly project(":apps:static:portal-k8s-agent:portal-k8s-agent-api")
 	compileOnly project(":core:petra:petra-string")
-
-	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 }


### PR DESCRIPTION
Hi @rotty3000, noticed that the CI was failing because of this:

 junit.framework.AssertionFailedError: Redundant dependency detected in modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/build.gradle expected:<compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"> but was:<testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default">

  at com.liferay.portal.modules.ModulesStructureTest._testGradleFile(ModulesStructureTest.java:1509)

  at com.liferay.portal.modules.ModulesStructureTest.access$800(ModulesStructureTest.java:68)

  at com.liferay.portal.modules.ModulesStructureTest$4.visitFile(ModulesStructureTest.java:402)

  at com.liferay.portal.modules.ModulesStructureTest$4.visitFile(ModulesStructureTest.java:376)

  at java.nio.file.Files.walkFileTree(Files.java:2670)

  at java.nio.file.Files.walkFileTree(Files.java:2742)

  at com.liferay.portal.modules.ModulesStructureTest.testScanGradleFiles(ModulesStructureTest.java:374)

So sending you the PR for review. Thanks!