### PR TITLE
LPS-180745 [WIP] Enable batch to site headless api

### DIFF
--- a/modules/apps/headless/headless-site/headless-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-site/headless-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Site API
 Bundle-SymbolicName: com.liferay.headless.site.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.headless.site.dto.v1_0,\
 	com.liferay.headless.site.resource.v1_0

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/dto/v1_0/Site.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/dto/v1_0/Site.java
@@ -239,6 +239,34 @@ public class Site implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected String parentSiteKey;
 
+	@Schema(description = "Base64 encoded file")
+	public String getSiteTemplateFile() {
+		return siteTemplateFile;
+	}
+
+	public void setSiteTemplateFile(String siteTemplateFile) {
+		this.siteTemplateFile = siteTemplateFile;
+	}
+
+	@JsonIgnore
+	public void setSiteTemplateFile(
+		UnsafeSupplier<String, Exception> siteTemplateFileUnsafeSupplier) {
+
+		try {
+			siteTemplateFile = siteTemplateFileUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "Base64 encoded file")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String siteTemplateFile;
+
 	@Schema
 	public String getTemplateKey() {
 		return templateKey;
@@ -412,6 +440,20 @@ public class Site implements Serializable {
 			sb.append("\"");
 		}
 
+		if (siteTemplateFile != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteTemplateFile\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(siteTemplateFile));
+
+			sb.append("\"");
+		}
+
 		if (templateKey != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -493,6 +535,7 @@ public class Site implements Serializable {
 	@GraphQLName("TemplateType")
 	public static enum TemplateType {
 
+		CLIENT_EXTENSION("client-extension"),
 		SITE_INITIALIZER("site-initializer"), SITE_TEMPLATE("site-template");
 
 		@JsonCreator

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
@@ -25,6 +25,8 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +38,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -53,6 +56,9 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface SiteResource {
 
 	public Site postSite(Site site) throws Exception;
+
+	public Response postSiteBatch(String callbackURL, Object object)
+		throws Exception;
 
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
@@ -92,6 +98,14 @@ public interface SiteResource {
 	public void setRoleLocalService(RoleLocalService roleLocalService);
 
 	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/dto/v1_0/Site.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/dto/v1_0/Site.java
@@ -163,6 +163,27 @@ public class Site implements Cloneable, Serializable {
 
 	protected String parentSiteKey;
 
+	public String getSiteTemplateFile() {
+		return siteTemplateFile;
+	}
+
+	public void setSiteTemplateFile(String siteTemplateFile) {
+		this.siteTemplateFile = siteTemplateFile;
+	}
+
+	public void setSiteTemplateFile(
+		UnsafeSupplier<String, Exception> siteTemplateFileUnsafeSupplier) {
+
+		try {
+			siteTemplateFile = siteTemplateFileUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String siteTemplateFile;
+
 	public String getTemplateKey() {
 		return templateKey;
 	}
@@ -279,6 +300,7 @@ public class Site implements Cloneable, Serializable {
 
 	public static enum TemplateType {
 
+		CLIENT_EXTENSION("client-extension"),
 		SITE_INITIALIZER("site-initializer"), SITE_TEMPLATE("site-template");
 
 		public static TemplateType create(String value) {

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
@@ -43,6 +43,13 @@ public interface SiteResource {
 	public HttpInvoker.HttpResponse postSiteHttpResponse(Site site)
 		throws Exception;
 
+	public void postSiteBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postSiteBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -240,6 +247,103 @@ public interface SiteResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-site/v1.0/sites");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteBatch(String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse = postSiteBatchHttpResponse(
+				callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/serdes/v1_0/SiteSerDes.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/serdes/v1_0/SiteSerDes.java
@@ -133,6 +133,20 @@ public class SiteSerDes {
 			sb.append("\"");
 		}
 
+		if (site.getSiteTemplateFile() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteTemplateFile\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(site.getSiteTemplateFile()));
+
+			sb.append("\"");
+		}
+
 		if (site.getTemplateKey() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -222,6 +236,14 @@ public class SiteSerDes {
 			map.put("parentSiteKey", String.valueOf(site.getParentSiteKey()));
 		}
 
+		if (site.getSiteTemplateFile() == null) {
+			map.put("siteTemplateFile", null);
+		}
+		else {
+			map.put(
+				"siteTemplateFile", String.valueOf(site.getSiteTemplateFile()));
+		}
+
 		if (site.getTemplateKey() == null) {
 			map.put("templateKey", null);
 		}
@@ -286,6 +308,11 @@ public class SiteSerDes {
 			else if (Objects.equals(jsonParserFieldName, "parentSiteKey")) {
 				if (jsonParserFieldValue != null) {
 					site.setParentSiteKey((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "siteTemplateFile")) {
+				if (jsonParserFieldValue != null) {
+					site.setSiteTemplateFile((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "templateKey")) {

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
@@ -8,6 +8,6 @@ author: "Rubén Pulido"
 clientDir: "../headless-site-client/src/main/java"
 compatibilityVersion: 2
 forcePredictableOperationId: true
-generateBatch: false
+generateBatch: true
 generateGraphQL: false
 testDir: "../headless-site-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
@@ -29,11 +29,16 @@ components:
                 parentSiteKey:
                     type: string
                     writeOnly: true
+                siteTemplateFile:
+                    description:
+                        Base64 encoded file
+                    type: string
                 templateKey:
                     type: string
                     writeOnly: true
                 templateType:
                     enum:
+                        - client-extension
                         - site-initializer
                         - site-template
                     type: string

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -16,31 +16,56 @@ package com.liferay.headless.site.internal.resource.v1_0;
 
 import com.liferay.headless.site.dto.v1_0.Site;
 import com.liferay.headless.site.resource.v1_0.SiteResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 
+import java.io.Serializable;
+
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -49,12 +74,14 @@ import javax.ws.rs.core.UriInfo;
  */
 @Generated("")
 @javax.ws.rs.Path("/v1.0")
-public abstract class BaseSiteResourceImpl implements SiteResource {
+public abstract class BaseSiteResourceImpl
+	implements EntityModelResource, SiteResource,
+			   VulcanBatchEngineTaskItemDelegate<Site> {
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites' -d $'{"membershipType": ___, "name": ___, "parentSiteKey": ___, "templateKey": ___, "templateType": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites' -d $'{"membershipType": ___, "name": ___, "parentSiteKey": ___, "siteTemplateFile": ___, "templateKey": ___, "templateType": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(description = "Adds a new site")
 	@io.swagger.v3.oas.annotations.tags.Tags(
@@ -69,8 +96,168 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 		return new Site();
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/sites/batch")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postSiteBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				Site.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<Site> sites, Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeConsumer<Site, Exception> siteUnsafeConsumer = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if ("INSERT".equalsIgnoreCase(createStrategy)) {
+			siteUnsafeConsumer = site -> postSite(site);
+		}
+
+		if (siteUnsafeConsumer == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for Site");
+		}
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(sites, siteUnsafeConsumer);
+		}
+		else {
+			for (Site site : sites) {
+				siteUnsafeConsumer.accept(site);
+			}
+		}
+	}
+
+	@Override
+	public void delete(
+			Collection<Site> sites, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<Site> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<Site> sites, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
 		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<Site>, UnsafeConsumer<Site, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
 
 	public void setContextCompany(
@@ -135,6 +322,87 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 
 	public void setSortParserProvider(SortParserProvider sortParserProvider) {
 		this.sortParserProvider = sortParserProvider;
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+
+			Sort[] sorts = new Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new Sort[0];
+		}
 	}
 
 	protected Map<String, String> addAction(
@@ -242,6 +510,9 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	}
 
 	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<Site>, UnsafeConsumer<Site, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -255,6 +526,10 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSiteResourceImpl.class);

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -35,8 +37,11 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerFactory;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 import com.liferay.sites.kernel.util.Sites;
+
+import java.io.File;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -199,6 +204,30 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				group, GetterUtil.getLongStrict(site.getTemplateKey()), 0L,
 				true, false);
 		}
+		else if (Objects.equals(
+					Site.TemplateType.CLIENT_EXTENSION,
+					site.getTemplateType())) {
+
+			byte[] bytes = Base64.decode(site.getSiteTemplateFile());
+
+			File tempFile = FileUtil.createTempFile(bytes);
+
+			File tempDir = FileUtil.createTempFolder();
+
+			try {
+				FileUtil.unzip(tempFile, tempDir);
+
+				SiteInitializer siteInitializer =
+					_siteInitializerFactory.create(
+						new File(tempDir, "site-initializer"), site.getName());
+
+				siteInitializer.initialize(group.getGroupId());
+			}
+			finally {
+				FileUtil.deltree(tempFile);
+				FileUtil.deltree(tempDir);
+			}
+		}
 		else {
 			String siteInitializerKey = "blank-site-initializer";
 
@@ -244,6 +273,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Reference
+	private SiteInitializerFactory _siteInitializerFactory;
 
 	@Reference
 	private SiteInitializerRegistry _siteInitializerRegistry;

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site.properties
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/site.properties
@@ -3,6 +3,10 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.site.dto.v1_0.Site
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.site.dto.v1_0.Site
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Site)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -182,6 +182,7 @@ public abstract class BaseSiteResourceTestCase {
 		site.setKey(regex);
 		site.setName(regex);
 		site.setParentSiteKey(regex);
+		site.setSiteTemplateFile(regex);
 		site.setTemplateKey(regex);
 
 		String json = SiteSerDes.toJSON(site);
@@ -194,6 +195,7 @@ public abstract class BaseSiteResourceTestCase {
 		Assert.assertEquals(regex, site.getKey());
 		Assert.assertEquals(regex, site.getName());
 		Assert.assertEquals(regex, site.getParentSiteKey());
+		Assert.assertEquals(regex, site.getSiteTemplateFile());
 		Assert.assertEquals(regex, site.getTemplateKey());
 	}
 
@@ -319,6 +321,14 @@ public abstract class BaseSiteResourceTestCase {
 
 			if (Objects.equals("parentSiteKey", additionalAssertFieldName)) {
 				if (site.getParentSiteKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("siteTemplateFile", additionalAssertFieldName)) {
+				if (site.getSiteTemplateFile() == null) {
 					valid = false;
 				}
 
@@ -506,6 +516,17 @@ public abstract class BaseSiteResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("siteTemplateFile", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						site1.getSiteTemplateFile(),
+						site2.getSiteTemplateFile())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("templateKey", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						site1.getTemplateKey(), site2.getTemplateKey())) {
@@ -671,6 +692,14 @@ public abstract class BaseSiteResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("siteTemplateFile")) {
+			sb.append("'");
+			sb.append(String.valueOf(site.getSiteTemplateFile()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("templateKey")) {
 			sb.append("'");
 			sb.append(String.valueOf(site.getTemplateKey()));
@@ -734,6 +763,8 @@ public abstract class BaseSiteResourceTestCase {
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				parentSiteKey = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				siteTemplateFile = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				templateKey = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());


### PR DESCRIPTION
- LPS-180690 Ignore expected log
- LPS-180959 Improve upgrade performace
- LPS-177095 Add setup and teardown
- LPS-177095 Add CanSearchByFilter test
- LPS-177095 Add AdminCanFilterTeamByTeamName test
- LPS-177095 SF
- LPS-175624 Add AdminCanFilterCaseHistoryByEnvironment test
- LPS-175624 Add AdminCanFilterCaseHistoryByError test
- LPS-175624 Add AdminCanFilterCaseHistoryTeam test
- LPS-175624 Add AdminCanFilterWithMultipleOptions test
- LPS-175624 Add AdminCanNotFilterForNonExistentCaseResult test
- LPS-175624 SF
- LPS-175594 Add setup and teardown
- LPS-175594 Add CanFilterByAssignee test
- LPS-175594 Add CanFilterByCaseName test
- LPS-175594 Add CanFilterByCaseType test
- LPS-175594 Add CanFilterByComponent test
- LPS-175594 Add CanFilterByEnviroments test
- LPS-175594 Add CanFilterByError test
- LPS-175594 Add CanFilterByPriority test
- LPS-175594 Add CanFilterByStatus test
- LPS-175594 Add CanFilterByTeam test
- LPS-175594 Add CanFilterWithMultipleOptions test
- LPS-175594 Add CanNotFilterForNonexistant test
- LPS-175594 Add CanSearchByFilter test
- LPS-160522 Add setup and teardown
- LPS-160522 Add AdminCanFilterCasesTabInRunComparisonResultByCaseName test
- LPS-160522 Add AdminCanFilterDetailsTabInRunComparisonResultByPriority test
- LPS-177112 Remove unused feature added by task LPS-94161
- LPS-177112 Remove some unused classes from the test package
- LPS-177112 Semantic versioning
- LPS-180337 Add CanUseObjectAuthorAndCurrentUserTermsInEmailNotificationOnCustomObject Test
-  LPS-181071 Increase TimeOut
- Revert "LPS-180528 Simplify"
- LPS-180528 Having a map doesn't improve performance, we already are obtaining the values directly from the tracker without doing any calculation
- LPS-180317 Define exception mappers for DuplicateGroup, GroupKey, IllegalArgument and NoSuchGroup exceptions
- LPS-180317 Make message consistent with "No site initializer was found"
- LPS-180293 Adapt _testPostSiteFailureDuplicateName
- LPS-180293 Adapt _testPostSiteFailureSiteTemplateInactive
- LPS-180293 Add _testPostSiteFailureInvalidKey
- LPS-180293 Add _testPostSiteFailureParentSiteNotFound
- LPS-180293 Add _testPostSiteFailureSiteInitializerNotFound
- LPS-180293 Add _testPostSiteFailureSiteTemplateNotFound
- LPS-180293 Add _testPostSiteFailureTemplateKeyNoTemplateType
- LPS-180293 Add _testPostSiteFailureTemplateTypeNoTemplateKey
- LPS-180293 Adapt messages according to patterns agreed on https://issues.liferay.com/browse/LPS-181443
- LPS-180293 Adapt tests
- LPS-180293 Move IllegalArgumentExceptionMapper to vulcan
- LPS-180293 Automatic SF
- LPS-180293 SF
- LPS-180293 Rename ExceptionMapper classes, so they contain the REST entity name (Site) instead of the internal entity name (Group)
- LPS-180293 Fix javadoc
- POSHI-494 Add new task to only format source Poshi files
- POSHI-494 Rename task
- POSHI-494 Semver
- POSHI-494 prep next
- LPS-182231 Fix sidebar RTL
- LPS-182231 Use card width in RTL drag and drop
- LPS-182231 Fix drag preview with RTL
- LPS-182231 Allow cancelling drag and drop by hovering invalid items
- LPS-182231 Allow dragging items to the top of the tree
- LPS-182204 Rename blogs display contexts
- LPS-182204 Move logic to new display context
- LPS-182204 Move all logic to the top
- LPS-182204 Put all asset logic together and avoid requesting tags twice
- LPS-182204 Hide comments when in a display page
- LPS-182204 Fix tests
- LPS-182204 Rename to match class under test
- LPS-181657 Update simulation-panel-entry template
- LPS-181657 Add test case dxp-7.4-u72
- LPS-181657 Move the logic to ProjectTemplateCustomizer
- LPS-181657 Fix test issues
- LPS-181657 Source Format
- LPS-182473 Fix failure in ProjectTemplatesTheme test
- LPS-182473 prep next
- LPS-182525 Consider TermRangeQuery to adapt the filter to the the new DDM indexing way.
- LPS-182525 Sort
- LPS-182421 Scope service registrations by companyId
- LPS-182421 SF
- LPS-182427 Extract component and adjust toolbar position when the alert appear
- LPS-182427 buildLang
- LPS-182294 Remove method reference with static field in class DDMFormGuestUploadFieldUtil
- LPS-182294 Fix the test
- LPS-182294 SF, inline
- COMMERCE-10917 Add functional tests
- POSHI-523 Fix unit tests
- LPS-181346 Add CanAssertPaginationOnFDSViewsPage test
- LPS-181346 Add assertDataSetView macro and update createDataSetView macro with 'for' function
- LPS-181346 Update CanAssertPaginationOnFDSViewsPage and CanCancelDeletionOnCloseButton test
- LPS-181348 Add test AssertNumberOfCharactersExceededInNameField
- LPS-181346 Update test CanCancelDeletionOnCloseButton
- LPS-181351 Add CanSearchViewByName test
- LPS-181343 Add CanCancelViewCreationOnCancelButton test
- LPS-181341 Add CanCreateViewWithNoDescription test
- LPS-181346 SF
- LPS-182049 Implementation of the custom field for listing the organization when creating the Request
- LPS-182049 Changing the field for input and validation
- LPS-182049 Fix to clear console freemarker error when creating EVP site
- LPS-182049 Removing taxIdentificationNumber and keeping only the taxId
- LPS-182049 Javascript code refactoring and ordering css classes
- LPS-182645 Remove useless DBProcessContext
- LPS-182645 Semantic versioning
- LPS-182495 Replaces current logo url with the logo url
- LPS-169170 Set loading to true when opening sidebar
- LPS-181094 Change the arial-label to class
- LPS-160463 Add tests for TestrayFiltersTaskAdministrator
- LPS-180251 Fixed wrong property on PartnerIcons
- LPS-180251 Fixed Level Dashboard Amount inconsistency
- LPS-180251 Changed Partner Roles
- LPS-181614 Replace custom ae_autolink plugin with ootb autolink plugin in FragmentEntryLinkEditor
- POSHI-494 Add new format task to README
- LPS-182561 Prevent NPE
- LPS-181257 Improve PublicationsTemplate.addPublicationTemplate macro
- LPS-181257 Add UseDefaultTemplateWhenCreatingNewPublication testcase
- LPS-181257 Improve Publications.enableSandboxOnly macro
- LPS-181257 Reorder
- LPS-181257 Spelling
- LPS-181257 Add description
- LPS-182590 Use partial text assertion
- LPS-160703 Add macro to case result
- LPS-160703 Add path to case result
- LPS-160703 Add AdminCanSeeIssuesInAllTables test
- LPS-160703 SF
- LPS-182367 Deactivate UpgradeConfigurationPidUpgradeTest integration tests failling due to LPS-176940
- LPS-182367 Since all test methods are failing, ignore the whole class
- LPS-180931 Update Upgrade testray main component names
- LRQA-80032 Wait for page to load after signin
- LRQA-80032 Use faster sign in macro and refresh after page loads
- LRQA-80032 Add additional checks for node messages
- LPS-182653 VelocityEngineFactory should not be a component.
- LPS-182653 Lazy creating SamlBindings
- LPS-182653 DBMetadataResolver is mandatory, make it explicit.
- LPS-182653 Fix unit tests
- LPS-182653 Lazy creating ChainingSignatureTrustEngine
- LPS-182653 Lazy creating MetadataCredentialResolver
- LPS-182653 Lazy creating PredicateRoleDescriptorResolver
- LPS-182653 Use ServiceTracker to collect MetadataResolver
- LPS-182653 Fix unit tests
- LPS-182653 Lazy creating CachingChainingMetadataResolver
- LPS-182653 Lazy creating Decrypter and it should not be optional.
- LPS-182653 Lazy creating SAMLMetadataEncryptionParametersResolver
- LPS-182653 Lazy creating HttpClient
- LPS-182653 Fix unit test
- LPS-182653 Lazy creating ParserPool and lazy bootstrap OpenSaml.
- LPS-182653 Fix unit test
- LPS-182653 Guard all ConfigurationService access with ConfigurationServiceBootstrapUtil to make sure bootstrap has been done.
- LPS-182653 Fix unit test
- LPS-182653 Allow a peaceful logging complain when fails to create Decrypter.
- LRCI-3543 Fix the hash code to avoid duplicate entities
- LRCI-3543 Add methods to get related objects from repository classes
- LRCI-3543 Remove references to creating relationships between objects in repository classes
- LRCI-3543 Create relationships on startup within the Queue objects
- LRCI-3543 Add more job parameters to the invocation json objects
- LRCI-3543 Add method to add a entities for Build, BuildParameter, & Project
- LRCI-3543 Fix the sorting for the different queues
- LRCI-3543 Add JMS events to create a build or project
- LRCI-3543 Add a method to join strings together
- LRCI-3543 Add method to initialize entity repositories
- LRCI-3543 Choose which projects are cached in the project repository
- LRCI-3543 Only expose search & filters for DALO classes
- LPS-182645 baseline
- LPS-182645 forgot this
- LPS-181584 Add new "download" action to DM
- LPS-181584 Check DOWNLOAD permission in services
- LPS-181584 Update widgets and http endpoints
- LPS-181584 Upgrade process
- LPS-181584 Check VIEW permission for previews and thumbnails
- LPS-181584 Set correct content type and use correct url in headless
- LPS-181584 Allow downloading when staging enabled
- LPS-179886 Forbid to download attachment if view permission not present in container
- LPS-179886 Build lang
- LPS-181584 Baseline
- LPS-181584 Sort
- LPS-181584 Sort
- LPS-181584 Sort
- LPS-180735 show the new configuration
- LPS-180736 update the value of the new configuration with the existing values of the LayoutSEODynamicRenderingConfiguration
- LPS-180736 add test to test the upgrade
- LPS-180736 use the method from the userAgentMatcher to know if the user agent is on the list of the crawler user agents
- LPS-180736 remove the crawlerUserAgents properties from the layout seo rendering configuration
- LPS-180736 put message to let the user know where the crawler user agent configuration is now
- LPS-180736 buildLang
- LPS-180736  no need of modify the include, hard code the message
- LPS-180736 change the message to add the route to the configuration
- LPS-180736 buildLang
- LPS-180736 baseline
- LPS-180736 Wordsmith
- LPS-180736 Regen
- LPS-182503 Use FunctionInfoLocalizedValue
- LPS-182503 Change method signature to receive the themeDisplay as a parameter
- LPS-182503 Adapt themeDisplay to the processed locale, pattern copied from GetPagePreviewStrutsAction and simplified, here we just need to change the locale
- LPS-182503 Restore the theme display original locale because when we set locale LocaleThreadLocal.setThemeDisplayLocale(locale) was invoked
- LPS-182503 SF buy space
- LPS-182503 SF inline, if-null condition removed because not-possible
- LPS-182503 Adapt tests
- LPS-182503 Set and restore the context
- LPS-182503 SF use local variables
- LPS-182503 Set the thread local site default locale when update the site display settings
- LPS-182503 Add an integration test to ensure the behavior
- LPS-182503 Add an integration test to assert the case of content with a default locale different from the site's default one. In this way, we assert that the content default locale is used as default instead of the site default one
- LPS-182503 SF
- LPS-182351 Add methods of the classes annotated with GraphQLTypeExtension of the GraphQL Query classes
- LPS-182351 Get the method name based on the GraphQLTypeExtension annotation
- LPS-182351 Inline and buy space
- LPS-182351 buildREST
- LPS-182351 prep next
- LPS-182410 prep next
- LPS-182351 LPS-182410 prep next
- LPS-182556 path refactor
- LPS-182643 Add test
- LPS-181771 Fixes
- LPS-181771 Add addUser macro
- LPS-181771 Add path to Testray User
- LPS-181771 Add AdminCanAddAndDeleteNewUser test
- LPS-181771 SF
- LPS-178959 Remove unnecessary css
- LPS-178959 Replace with classes
- LPS-178959 Adapt clickable area
- LPS-182523 Adds reviewDate to JournalArticle and DLFileEntry model contributors
- LPS-182523 Adds to search files
- LPS-182523 Implements filter by review date
- LPS-182523 buildLang
- LPS-182523 Update tests
- LPS-182523 Rename following pattern _getXyzDropdownItems
- LPS-182523 Rename to getReviewDateString
- LPS-182523 SF
- LPS-182523 https://capitalizemytitle.com/
- LPS-182523 Regen
- LPS-170377 Remove method reference with static field in class KBServiceConfigurationProviderUtil
- LPS-170377 Inline
- LPS-182296 Simplify, no need to use a static method to return a fixed String value
- LPS-182296 SF, remove redundant method _getTempImageFileName() from UploadImageMVCActionCommand by using the one in UploadImageUtil
- LPS-182296 Remove method getTempImageFileName() from UploadImageUtil by using ParamUtil.getString() directly
- LPS-182296 Extract the component logic from UploadImageUtil into a new component class, prep next
- LPS-182296 Change UploadImageUtil to a non-component class by using Snapshot and the new Component class
- LPS-182296 This configuration is no longer used since LPS-147561 (moved to util)
- LPS-182296 Use existing APIs so that we don't need to extract the logic to a new component
- LPS-182296 I think this was the original logic
- LPS-182296 Inline
- LPS-179523 Add logic check avoid import old taglib
- LPS-179523 Add IllegalTaglibCheck check avoid use old taglib
- LPS-179523 Generated
- LPS-179523 SF
- LPS-179523 Rename
- LPS-179523 This should be here
- LPS-179523 Reduce variable
- LPS-179523 Reword
- LPS-179523 Fix incorrect ticket number
- LPS-179523 Remove unneeded comments, as we already have them in messages
- LPS-179523 Rename, use plural
- LPS-179523 Not needed
- LPS-179523 Not needed
- LPS-179523 Rename
- LPS-179523 Simplify
- LPS-179523 SF
- LPS-179523 Buy space
- LPS-179523 SF
- LPS-179523 Reword
- LPS-179523 SF
- LPS-179523 Rename, use plural
- LPS-179523 Simplify
- LPS-179523 Generated
- LPS-179523 Fix incorrect ticket number in test case
- LPS-179523 Update illegal taglib properties
- LPS-182581 Set the default locale to the InfoForm structure's fieldSet label
- LPS-182581 Set the default locale to the AssetVocabulary title localized value
- LPS-182581 Set the proper default locale to others info field localized values
- LPS-182581 Set all the available values and use a default locale the ddmTemplate default instead of the instance default
- LPS-182581 SF
- Revert "LPS-182296 Inline"
- Revert "LPS-182296 I think this was the original logic"
- LPS-180956 Extract COREntryDetailsScreenNavigationCategory methods to a COREntryDetailsScreenNavigationEntry component and extend COREntryDetailsScreenNavigationCategory in it
- LPS-180956 Extract COREntryQualifiersScreenNavigationCategory methods to a COREntryQualifiersScreenNavigationEntry component and extend COREntryQualifiersScreenNavigationCategory in it
- LPS-180956 Add "-dsannotations-options: inherit"
- LPS-180956 Extract CommerceTaxMethodAvalaraRateRelsScreenNavigationCategory methods to a CommerceTaxMethodAvalaraRateRelsScreenNavigationEntry component and extend CommerceTaxMethodAvalaraRateRelsScreenNavigationCategory in it
- LPS-180956 Extract constants from CommerceTaxMethodAvalaraRateRelsScreenNavigationCategory and CommerceTaxMethodAvalaraRateRelsScreenNavigationEntry to CommerceTaxScreenNavigationConstants and apply them to usages
- LPS-180956 Extract CommerceTaxMethodAvalaraScreenNavigationCategory methods to a CommerceTaxMethodAvalaraScreenNavigationEntry component and extend CommerceTaxMethodAvalaraScreenNavigationCategory in it
- LPS-180956 Extract constants from CommerceTaxMethodAvalaraScreenNavigationCategory and CommerceTaxMethodAvalaraScreenNavigationEntry to CommerceTaxScreenNavigationConstants and apply them to usages
- LPS-180956 Add "-dsannotations-options: inherit" in commerce-avalara-tax-engine-fixed-web module bnd
- LPS-180956 Extract CSDiagramCPTypeScreenNavigationCategory methods to a CSDiagramCPTypeScreenNavigationEntry component and extend CSDiagramCPTypeScreenNavigationCategory in it
- LPS-180956 baseline
- LPS-178800 Add a macro to get and delete keywords
- LPS-178800 Add a macro to get and update object entries
- LPS-178800 Update macro to move and modify the macro
- LPS-178800 Update a testcase to modify the correct macro
- LPS-178800 Add a testcase to manage keywords associated to object entries
- LPS-178800 Update macro to delete duplicate macro
- LPS-171387 New class to control the status of the upgrade process. It takes some logic from the UpgradeReport to get the events information
- LPS-171387 Baseline
- LPS-171387 Adding new exception to SF rule to avoid check on file that does not require check
- LPS-171387 Upgrade report should only be generated when the upgrade.report.enabled property is true, but the UpgradeReportLogAppender needs to be created always to collect data needed for the DBUpgradeStatus class
- LPS-171387 Renaming class as now it is not related exclusively to the upgrade report but the upgrades in general
- LPS-171387 Calculating the type of upgrade at the end, based on the initial an final schema versions
- LPS-171387 Optimization to avoid reading Release_ table when not needed
- LPS-171387 New component to check if there are pending pending upgrades to be run and unresolved UpgradeStepRegistrator components
- LPS-171387 Applying new DBUpgradeChecker component at the end of upgrades
- LPS-171387 Printing the upgrade type and result in the log when the upgrade is finished
- LPS-171387 Improving naming
- LPS-171387 For portal, schemaVersion 0.0.0 means that it has not been possible to obtain the value
- LPS-171387 Fixing BDUpgradeTest class by initializing variables properly before test executions
- LPS-171387 Fixing integration tests by resetting the DBUpgradeStatus variables on every test run
- LPS-171387 Adding integration tests for DBUpgradeStatus class
- LPS-171387 Adding integration tests for DBUpgradeCheckerImpl class
- LPS-171387 Better naming
- LPS-171387 Fixing broken tests
- LPS-171387 Better naming
- LPS-171387 Adding check to avoid NPE when querying for the schema version of a module that has not been found in the Release_ table
- LPS-171387 Do it inline
- LPS-171387 When running the upgrade client we can disable the auto upgrade but we should also get the Upgrade Status
- LPS-171387 Centralize all release checks in ReleaseManagerImpl
- LPS-171387 Refactor and include unsatisfied Upgrade components check
- LPS-171387 Remove usage of DBUpgradeChecker in favour of ReleaseManager
- LPS-171387 SF remove inmediate = true
- LPS-171387 No need to specify DB
- LPS-171387 Name Maps with the value
- LPS-171387 Naming
- LPS-171387 Improve log messages
- LPS-171387 Move the implementation to the portal-upgrade-impl module & BASELINE
- LPS-171387 No need to pass references since now it is a component
- LPS-171387 Inline
- LPS-171387 Differentiate between Status vs State. See https://stackoverflow.com/questions/1162816/naming-conventions-state-versus-status
- LPS-171387 Not need to be static now
- LPS-171387 Simplify logic
- LPS-171387 Simplify
- LPS-171387 Naming
- LPS-171387 use volatile when it is not threadSafe
- LPS-171387 Refactor to do not use other module's bundle symbolic name
- LPS-171387 Add test for missing Portal upgrade
- LPS-171387 This reference is required
- LPS-171387 Theses references need to be dynamic and greedy
- LPS-171387 Clearer output
- LPS-171387 Not need to tie this test to the Upgrade Appender or Watch
- LPS-171387 Do not tie the test to the Upgrade watch
- LPS-171387 Only restore what is needed
- LPS-171387 We forgot to remove the appender. Test won't work when starting up the server with auto upgrade otherwise since we were referencing to the old appender instance
- LPS-171387 Not needed and replacement
- LPS-171387 Assert only the necessary and in the proper place
- LPS-171387 Do not use predefined release records. Reorganize
- LPS-171387 Renaming
- LPS-171387 Make it more real
- LPS-171387 Avoid issue with LogAssertionTestRule when printing an error in the log
- LPS-181387 Interface UpgradeStatus should have only two public methods for getting the state and type of the upgrade
- LPS-171387 Rename
- LPS-171387 Simplify
- LPS-171387 Making inner class methods private as they are not used outside the outer class and it prevents a SF check to fail
- LPS-171387 Auto SF
- LPS-171387 Update report log messages
- LPS-171387 Follow same name pattern
- LPS-171387 Baseline
- LPS-171387 Unregistering service properly when finishing test
- LPS-171387 Not need to do this outside the method
- LPS-171387 New status for unresolved dependencies
- LPS-171387 This case is unresolved
- LPS-171387 Better name
- LPS-171387 Use isUpgraded because at this point we don't check the results, just if the upgrade is complete. Adding more complete tests too
- LPS-171387 Do not expose UpgradeStatus for now
- LPS-171387 Use Recorder and result because we capture the initial upgrade. It is not a live status
- LPS-171387 SF
- LPS-171387 SF
- LPS-181162 Removes feature flag LPS-177031
- LPS-182521 Product QA | Functional Automation - LPS-177832
- LPS-77699 Update Translations
- LPS-182638 Fixing test and Add new setps on stup
- LPS-182638 Fixing macros for test fixing
- LPS-175569 Fix name
- LPS-175569 Use current conjunction for first criteria instead of forcing AND
- LPS-182680 Adds type to advanced panel, since without it we cannot add the field to a journal structure
- LPS-182680 Updates tests
- LPS-181688 Replace getCN with classNames
- LPS-181688 Update snapshots
- LPS-179842 Adds an upgrade step to remove JournalArticle ddmStructureKey DB column
- LPS-179842 Delete removed column-related test, it won't be useful anymore
- LPS-182189 Remove JournalFeed ddmStructureKey DB column using the same step
- LPS-182189 Delete removed column-related test
- LPS-179842 and LPS-182189 Update schema version
- LPS-182189 Remove DDMStructureKey field
- LPS-182189 Adapt DDMStructure table reference
- LPS-182189 BuildService
- LRAC-13375 osb-faro-mock-provisioning-client: Update build.gradle
- LRAC-13375 osb-faro-mock-provisioning-client:Apply SF
- LRAC-13368 osb-faro-contacts-demo:Update build.gradle
- LRAC-13368 osb-faro-contacts-demo:Use HashMapBuilder
- LRAC-13368 osb-faro-contacts-demo:Use TransformUtil
- LRAC-13368 osb-faro-contacts-demo:SF
- LPS-169278 Add label for edit/new item name input
- LPS-182527 Update cases for UI change in LPS-153953
- LPS-181570 Use the fiendly URL if the file entry has a display page
- LPS-182365 Setting customFields = null if not present in PATCH request
- LPS-182365 buildREST
- LPS-182365 No longer needed
- LPS-182365 prep next
- LPS-151626 not sure why it's there
- LPS-180241 Follow up to cover a new user case, comment of multiple lines
- LPS-182065 Create UpgradeVelocityIfStatementsMigrationCheck
- LPS-182065 Generated
- LPS-182067 Update UpgradeVelocityMigrationCheck-testvm/testftl to cover the new check
- LPS-182065 prep next
- LPS-182065 LPS-182365 prep next
- LPS-161525 If HSQL is being used for development, disable autoupgrade
- LPS-161525 Update property description
- LPS-161525 Semantic versioning
- LPS-161525 Keep final restriction when possible
- LPS-161525 More verbose
- LPS-161525 Sort
- LPS-161525 Wordsmith
- LPS-182033 Use the date format of the current locale to determine parsing pattern
- LPS-182033 Parse the stored date using the best fitting pattern
- LPS-182033 Consider the site's default locale to parse
- LPS-182033 SF simplify
- LPS-182033 If the target locale is available it should be used
- LPS-182033 SF
- LPS-182033 Adds an integration test to assert that when processing a date's type info field, the value will be properly formatted according to each locale
- LPS-182033 Use the same pattern to fix the same issue on the Information Template fields
- LPS-182033 Adds an integration test to assert that when creating a TemplateNode the date info field values will be properly formatted according to each locale
- LPS-182033 Don't randomize the field names to prevent a flaky test because if the name starts with a number the freemarker template will fail
- LPS-181454 Add JSImportmapsEntry client extension
- LPS-181454 Make the client extension do something useful
- LPS-181454 Register the client extension in the Workspace
- LPS-181454 Add a sample project for JS import maps client extension
- LPS-181454 Unify criteria for "importmaps" vs "importmap"
- LPS-181454 Refactor how things are deployed
- LPS-181454 Prefer Import Maps to Importmaps (for labels)
- LPS-182182 Fix CSS and JS helps labels
- LPS-181454 gradle buildLang
- LPS-181454 gradle baseline
- LPS-181454 Put the feature behind a FF
- LPS-181454 Wordsmith
- LPS-181454 gradle buildLang
- LPS-181454 Rename configurationPid
- LPS-181454 ant update-portal-osgi-configuration-properties
- LPS-181454 gradle baseline
- LPS-181454 Rename to base
- LPS-181454 Should this be base or IFrame?
- LPS-181454 Match com.liferay.client.extension.type.IFrameCET
- LPS-181454 Rename
- LPS-181454 Rename
- LPS-181454 Match com.liferay.client.extension.type.IFrameCET
- LPS-181454 Leverage method overloading
- LPS-181454 Inline
- LPS-181454 Is this line really needed?
- LPS-181454 Inline
- LPS-181454 Rename
- LPS-181454 Rename?
- LPS-181454 Wordsmith
- LPS-181454 Regen
- LPS-181454 Rename
- LPS-181454 auto SF
- LPS-181454 Rename custom element name
- LPS-181454 SF sample workspace project
- LPS-181454 Rebuild import maps when scoped objects change
- LPS-181454 Temporary SF suppression
- LPS-181415 Success message when form is submitted
- LPS-181415 Formatting
- LPS-181415 Added form validation messages
- LPS-181415 Fixed text
- subrepo:ignore Update 'modules/dxp/apps/osb/osb-faro/.gitrepo'.
- LPS-182749 Change in the overflow property to get page scroll
- LPS-182322 Refinement, rename and hide buttao
- LPS-178022 Replace Optional method usages with string method instead in SearchResultsPreferences
- LPS-178022 Remove Optional method in SearchResultsPreferences, no more usages
- LPS-178022 Remove "String" from method names, no longer necessary
- LPS-178022 Apply to usages
- LPS-178022 Remove Optional usage from SearchResultPreferences getFieldsToDisplay method
- LPS-178022 Apply to usages
- LRQA-80226 Add test suites for portal proxy path and non root context
- LRQA-80226 Do not clean deploy dir in test suites
- LRQA-80226 Update default portal url property
- LRQA-80226 Fix for getting the instance name
- LRQA-80226 Change context right before startup portal
- LRQA-80226 Fix for getting site name
- LRQA-80271 Go to Design navigation tab first
- LRQA-80271 SF
- LRQA-80382 Remove assert for 10080 node as test only uses two nodes
- ISSITES-6074 dashboard refinements
- LPS-182744 Apply permission logic in users in SuiteCase
- LPS-182748 Analyze button appearing when user has no permission
- LPS-182256 Status "NOT_FOUND" when edit subtask with Testray administrator role
- LPS-181820 Create UpgradeVelocityFileImportMigrationCheck
- LPS-181821 Update UpgradeVelocityMigrationCheck-testvm/testftl to cover the new check
- LPS-181820 Generated
- LPS-178022 Replace optional methods usages with string method instead
- LPS-178022 Remove optional methods, no more usage
- LPS-178022 Remove "String" from method names, no longer necessary
- LPS-178022 Replace optional method usages with string method instead
- LPS-178022 Remove optional methods, no more usage
- LPS-178022 Remove "String" from method names, no longer necessary
- LPS-179114 gradle-plugins-workspace: simplify: makes the Project a field
- LPS-179114 gradle-plugins-workspace: adds annotated getter methods for input files
- LPS-179114 gradle-plugins-workspace: uses getter functions when reading file content
- LPS-179114 gradle-plugins-workspace: cleanup: consolidates writing to output with template backup
- LPS-179114 gradle-plugins-workspace: cleanup: inlines and simplifies the logic for retrieving and interpolating template content
- LPS-179114 prep next
- LPS-161481 SF, inline
- LPS-161481 SF, no logic change
- LPS-161481 Should only validate max company users when necessary, the validate logic was added to UserLocalServiceImpl by LPS-29673(46c7bdfe708dda4197b5f98605a776979f4a5176) to fix an issue when user status changed by RESTORE action, this should not be expanded to other cases by modifying local service logic.
- LPS-161481 Rename to match RoleLocalServiceImpl#validateName
- LPS-161481 Auto generated
- LPS-181130 - Fix ProcessBuilderListView#CanOrderByTitle
- LRQA-80361 test-fix
- LRQA-80361 SF
- LPS-182458 Add option to add document as other user
- LPS-182458 Add more JSON layout widget options
- LPS-182458 Use JSON to add widgets, document, and blog entry
- LPS-182458 Remove skip portal instance
- LPS-182640 File renaming and exporting testcases
- LPS-182260 Add refresh to try to stabilize CanCreateAction test
- LPS-182570 Fix next steps page url call
- LPS-182800 Fix add button redirection on Publisher and Dashboard pages
- LPS-182535 Use WaitForElementPresent for created account
- LPS-181808 adding the bug ticket that is making us leave the tests on quarantine
- LPS-181808 removing ignore from test HasMandatoryFieldErrorMessagesWhenEmpty
- LRQA-80364 change made to name FDSViews#CanDeleteView
- LPS-181603 Create removed field to logic of deleting activities and budgets
- LPS-181603 Fix activies requests
- LPS-181603 Fix required fields when editing MDF Request
- LPS-181603 Change delete budget to update
- LPS-181603 Improve code to handle errors
- LPS-181603 Add validation for bugets and activities
- LPS-182802 The first segment name is not correctly on Organization dropdown list
- LPS-181339 Add FDSViews#CanCreateView
- LPS-181747 correction with new value "sample3" and remove ignore
- LPS-182564 Remove Panel.expandPanel macro
- LRCI-3575 Fix poshi test running within workspaces
- LRCI-3575 Update refresh_other_workspaces.sh to account for poshi tests
- LRCI-3575 Refresh other workspaces
- LRCI-3575 Create a new batch called workspace-compile-jdk8
- LRCI-3575 Add workspace-compile-jdk8 batch to the stable suite
- LRCI-3575 Allow workspace changes to be tested again
- LRCI-3575 Fix references to the build.gradle file
- LRCI-3575 Temporarily disable compiling liferay-sample-workspace until it has been fixed
- LRCI-3575 Remove unnecessary maven reference
- LRCI-3575 Apply to script
- LRCI-3575 regen
- LPS-178022 Replace optional method usages with string method instead
- LPS-178022 Remove optional methods, no more usage
- LPS-178022 Remove "String" from method names, no longer necessary
- LPS-178022 SF, rename
- LPS-178022 #sfme
- LPS-181600 Unselect budgets after unselect Activity
- LPS-181600 Yup validation, Need at least one budget selcted if activity selected
- LPS-181600 Perform fragment freeMarker to show only budgets selected
- LPS-181600 formatSource
- LPS-181600 Add change selected mdf claim activity
- LPS-181600 Show only selectd claims
- LPS-182546 Set explicitly the default locale to labels to ensure we will use the object definition defaultLocale as default instead of the instance default
- LPS-182546 Apply same pattern to localized object field labels
- LPS-182546 Set the proper default locale to listTypeEntry info field localized values
- LPS-172441 upgrade snakeyaml to 2.0 in source-formatter.properties
- LPS-172441 auto sf
- LPS-172441 add LoaderOptions() to Constructor(). In snakeYAML 2.0, these options are required while declaring Constructor(). Please see https://bitbucket.org/snakeyaml/snakeyaml/commits/68d199a0ef93fbc02639f891d06ea994b6134a0e
- LPS-172441 add DumperOptions() to Representer(). In snakeYAML 2.0, this option is required while declaring Representer(). Please see https://bitbucket.org/snakeyaml/snakeyaml/commits/094691f9392fbf6997d05aeaa4c615a434b41120
- LPS-172441 add -fixupmessages to ignore the classes found in wrong direcotry, so that it can successfully build the modules
- LPS-172441 manually upgrade jackson-dataformat-yaml to version 2.14.2 to fit the upgrade of snakeYAML 2.0
- LPS-172441 auto generate, by running "ant build-lib-versions"
- LPS-172441 prep next
- LPS-172441 prep next
- COMMERCE-11346 Remove expand Look and Feel panel macro
- LPS-178862 Add description prop to taglib
- LPS-178862 Add margin to image
- LPS-178862 Use new taglib
- LPS-178862 Good enough
- LPS-182403 Moves logic
- LPS-182403 It is not necessary to replace the document, since we are already modifying DDMFormFieldValues
- LPS-182403 Reorder logic to make the replacements to ddmFormValues and convert into a string at the end
- LPS-182403 We don't need to check permissions on export/import
- LPS-182403 Inline
- LPS-182403 Extract JournalArticle field logic to a new DDMFormFieldValueTransformer
- LPS-182403 Moves to the correct package
- COMMERCE-9805 introduce new exceptions
- COMMERCE-9805 Add checks to prevent subscriptionCycles being less than 0
- COMMERCE-9805 add new exception mappers
- COMMERCE-9805 gw buildService
- COMMERCE-9805 gw baseline
- LPS-178777 Remove stub for CanCreateDataSetViaAPI
- LPS-178777 Add macro addDataSetViaAPI
- LPS-178777 fix JSON macro after update
- LPS-178777 add CanCreateDataSetViaAPI test
- LPS-178777 Add _createDatasetEntry macro
- LPS-178777 Add createDatasetEntryViaAPI macro
- LPS-178777 Add CanCreateDatasetEntryViaAPI testcase
- LPS-178777 SF
- LPS-178777 Go to dataset admin page before create a dataset entry via api
- LPS-181293 Change styling on File Size Limits settings for D&M
- LPS-178022 Replace optional method usages with string method instead
- LPS-178022 Remove optional methods, no more usage
- LPS-182646 Do not retry
- LPS-182646 Temporarily skip portal instance
- LPS-182314 Return download url, not the one for the preview
- LPS-182314 Omit content url if no content or no permissions to download
- LPS-182314 Tests
- LPS-182314 Like this
- LPS-182314 Inline until it's reused
- LPS-160434 Remove the method setPortlet, prepare for the next
- LPS-160434 Use method getPortlet to get portlet ,remove variable _portlet and just implement method getPortlet in subclasses
- LPS-160434 Apply, directly reference Portlet and return via getPortlet()
- LPS-160434 Apply to ObjectEntriesPanelApp
- LPS-160434 Apply to PortletPanelAppAdapter
- LPS-160434 Convert method references to field references
- LPS-160434 Update Project Template
- LPS-160434 Fix tests
- LPS-160434 semantic versioning
- LPS-160434 SF
- LPS-181310 Add new uniqueValues setting to Text and Integer object fields
- LPS-181310 Create BaseObjectFieldBusinessType to reuse code
- LPS-181310 Add validation for new setting uniqueValues
- LPS-181310 Move toObjectFieldSetting logic to ObjectFieldDTOConverter as it is only used once
- LPS-181310 Make public the method responsible for converting the value of an object field setting so it can be reused
- LPS-181310 Convert value, returned by the headless API, for the uniqueValues ​​setting
- LPS-181311 Add new method and exception to validate if user is trying to change the object field setting value after the object is already published
- LPS-181311 Validate if user is trying to change the uniqueValues value after the object is already published
- LPS-181310 Add feature flag
- LPS-181312 Create unique index for each unique object field when publishing the object
- LPS-181312 Change insertIntoOrUpdateExtensionTable to receive userId
- LPS-181312 Fix usages
- LPS-181312 Show error message if value is not unique when submitting the Object Entry
- LPS-181312 buildLang
- LPS-181312 buildService
- LPS-181310 baseline
- LPS-182370 Transform the static component NPMResolverProvider into a Util class using a Snapshot field
- LPS-182370 Transform the static component ClayTagContextContributorsProvider into a Util class initializing the Service tracker into a static block instead of an activate method
- LPS-182370 Transform the static component NPMResolverProvider into a Util class using a Snapshot field
- LPS-182370 Transform the static component DynamicSectionUtil into a Util class initializing the Service tracker into a static block instead of an activate method
- LPS-182370 Transform the static component SoyComponentRendererProvider into a Util class using a Snapshot field
- LPS-182370 Add dependencies
- LPS-181306 Rename filterSettings to removeFieldSettings and move it to appropriate file
- LPS-181306 Update types
- LPS-181306 Create unique values component and add it to field form base
- LPS-181306 Prevent max length toggle from clearing all field settings
- LPS-181306 Add language key
- LPS-181306 Build languages
- LPS-181306 Add feature flag
- LPS-181306 Wordsmith
- LPS-181306 Regen
- LPS-145789 Create test for JournalArticle and File specificFields
- LPS-145789 Move unit test to integration tests
- LPS-145789 Delete unit tests
- LPS-145789 Simplify
- LPS-145789 Avoid duplicated code
- LPS-145789 Reuse themeDisplay
- LPS-145789 Extract common logic into a new method
- LPS-145789 It's not necessary
- LPS-145789 It's not necessary set the portraitId
- LPS-145789 Uses _serveResource method like in the other tests instead of ReflectionTestUtil
- LPS-145789 Uses diamond operator
- LPS-145789 Inline
- LPS-145789 SF
- LPS-145789 Uses AssetTestUtil
- LPS-145789 Reorder
- Baseline
- LPS-182623 Supply SourceProcessor object when initializing JavaTerm checks
- LPS-182657 Remove Stream usages in DeletionSystemEventImporter
- LPS-182657 Remove Stream usages in LayoutImportController
- LPS-182657 Remove Stream usages in CPDefinitionIndexer
- LPS-182657 Simplify, use TransformUtil.
- LPS-182657 SF, inline variable.
- LPS-182657 Simplify
- LPS-181778 Add dependencies
- LPS-181778 Transform the static component OptimizeImagesStatusMessageSenderUtil into a Util class using a Snapshot field
- LPS-181778 Transform the static component AMImageOptimizerUtil into an Util class initializing the Service tracker into a static block instead of an activate method
- LPS-181778 Transform the static component ItemSelectorUtil into an Util class using a Snapshot field
- LPS-181778 As used
- LPS-182722 Content and Full Page Applications should be retieved as well
- LPS-182722 Inline the array
- LPS-182114 There is still other Utils needs this to wait for initialization.
- LPS-182705 Use plural name instead, as in some cases it does not match with the schemaName followed by s
- LPS-182705 buildREST
- LPS-182705 prep next
- LPS-182705 prep next
- LPS-182347 add action to the modal select
- LPS-182347 put the tags on the label item List
- LPS-182347 re-use method
- LPS-182347 extract method
- LPS-182347 select all on the dropdown when the tags are empty and deselect the tag when you select all
- LPS-182347 add the assetTagIds to the search content
- LPS-182347 SF
- LPS-161481 regen
- LPS-181665 Cleanup, remove unused methods
- LPS-181665 Add a new Component class, prep next
- LPS-181665 Change CaptchaUtil to a non-Component class by using Snapshot with the new Component class
- LPS-181665 Baseline
- LPS-182823 Remove Optional usages in DDMFormEvaluatorExpressionFieldAccessor
- LPS-182823 Remove Optional usages in DDMFormLayoutJSONDeserializer
- LPS-182823 Remove Optional usages in DefaultDDMFormValuesFactory
- LPS-176421 add macro for add child page with confirm
- LPS-176421 add macro for add page in site template
- LPS-176421 testcases for page friendly url conllision
- LPS-180439 Add macro to grant user access to site
- LPS-180439 Add macro to add page with confirm
- LPS-180439 Add testcases for page friendly url collision in site
- LPS-174662 Add test ObjectUpgrade#ViewObjectEntryAfterUpgrade7413U33
- LPS-179330 Replace page load with wait for element present
- LPS-182698 Uses Set instead of an Array
- LPS-182698 Calculate it only once
- LPS-182698 Check permissions only if we are going to include actions
- LPS-182698 Inline
- LPS-182698 Include target for the same cases of regularURL
- LPS-182698 Simplify
- LPS-182698 Moves logic to main method to execute this logic only once
- LPS-182698 Adds new method that accept groupId
- LPS-182698 Auto
- LPS-182698 Uses new method
- LPS-182698 baseline
- LPS-182851 Run the test on default environment
- LPS-180070 Update INPUT_METHOD and INPUT_VALUE Paths to can input multiples values
- LPS-180070 Update fillObjectAction Macro to input multiples values with a new macro
- LPS-180070 Add CanAddUserAfterCreatingCommerceProductEntry Test
- LPS-180579 Make modal appear for users to move KB articles and folders easier
- LPS-181293 Add move by clicking on other hierarchy item
- LPS-181293 Component renaming
- LPS-181293 Renaming to avoid confusion with item selector variables
- LPS-181293 Restructure onSelect function to use its own arguments
- LPS-181293 Rename URLs and destinationItem to give more context
- LPS-181293 Sort and remove random blank line
- LPS-181293 Sort and remove random blank line
- LPS-77699 Update Translations
- LPS-176632 Inline DefaultFacetProcessor, it serves as a fallback and doesn't need to be a component
- LPS-176632 Inline CompositeFacetProcessor into BaseSolrQueryAssemblerImpl, since it's only used there
- LPS-176632 Convert method references to ServiceTrackerMap
- LPS-176632 Inline private method _processFacet, since it's only used there
- LPS-176632 Make method getFacetParameters private, since it's only used in class BaseSolrQueryAssemblerImpl
- LPS-176632 Make the methods in classes SearchRequestExecutorFixture and SolrSearchEngineAdapterFixture non-static, there is no need to be static
- LPS-176632 Fix tests(passing class FacetProcessor is actually just to create class BaseSolrQueryAssemblerImpl in class SearchRequestExecutorFixture)
- LPS-176632 Add dependencies
- LPS-173651 test automation - ViewOnlyGlobalTagsShownInObjectInstanceScope
- LPS-173651 test automation - ViewAllTagsShownInObjectSiteScoped
- LPS-173651 add ENABLE_CATEGORIZATION_BUTTON path
- LPS-173651 test automation - ViewWarningMessageWithCategorizationDisabled
- LPS-173651 test automation - CanUseTagsInPageTemplate
- LPS-173651 test automation - CanUseTagsInMasterPage
- LPS-173651 add TAGS_FRAGMENT_BY_ROW path
- LPS-173651 add if for select tag fragment by row in selectTag macro
- LPS-173651 test automation - CanAdd10TagsFragmentsToPage
- LPS-182527 Add steps in cases to check tags field is not required
- LPS-182527 Comment out the places to be changed after LPS-182835
- LPS-182527 Move cases to form components and change some texts in cases
- COMMERCE-11356 Update path COOKIES_CONSENT_PANEL_TITLE
- COMMERCE-11356 Add test CanHandleDeclinedCookiesUsingProductComparison
- LPS-180745 Activate generateBatch
- LPS-180745 Change rest-openapi.yaml
- LPS-180745 Regen buildRest
- LPS-180745 Create site initializer from file
